### PR TITLE
pytests ci containers label fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ unittests: ## Run unittests
 pytest: ## Run functional tests
 	docker pull ci.arenadata.io/functest:u18-x64
 	docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock --network=host -v $(CURDIR)/:/adcm -w /adcm/ \
-	-e ADCM_TAG=${BRANCH_NAME} -e ADCMPATH=/adcm/ ci.arenadata.io/functest:u18-x64 /bin/sh -e ./pytest.sh
+	-e BUILD_TAG=${BUILD_TAG} -e ADCM_TAG=${BRANCH_NAME} -e ADCMPATH=/adcm/ ci.arenadata.io/functest:u18-x64 /bin/sh -e ./pytest.sh
 
 ng_tests: ## Run Angular tests
 	docker pull ci.arenadata.io/functest:u18-x64


### PR DESCRIPTION
pytests are running in docker environment which is running from script of adcm repo that don`t inherit jenkins environment.

To fix need to set for container launch option -e BUILD_TAG=$BUILD_TAG.

For local launch we will have

```python
>> os.environ.get(BUILD_TAG)
''
```
which is still false in python