### PR TITLE
CI : fix container tag bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Set number of threads
-BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
+BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD | tr '/' '_')
 ADCMBASE_IMAGE ?= arenadata/adcmbase
 ADCMBASE_TAG ?= 20191206180316
 


### PR DESCRIPTION
while building branch dependabot/go_modules/go/adcm/develop/github.com/stretchr/testify-1.4.0 make build fails with error
"invalid referance format"
this commit changes symbol / on _ in adcm image tag that is formed from branch name.