### PR TITLE
ADCM-965 fix coreapi schema for license api

### DIFF
--- a/api/stack_views.py
+++ b/api/stack_views.py
@@ -136,6 +136,7 @@ class BundleUpdate(GenericAPIView):
 
 
 class BundleLicense(GenericAPIView):
+    action = 'retrieve'
     queryset = Bundle.objects.all()
     serializer_class = api.stack_serial.LicenseSerializer
 


### PR DESCRIPTION
(change action type from list to read for /api/v1/stack/bundle/1/license/)