### PR TITLE
ADCM-1080 Fixup if=0 files in /var/log/nginx

### DIFF
--- a/conf/nginx/adcm.conf
+++ b/conf/nginx/adcm.conf
@@ -60,8 +60,9 @@ server {
     }
 
     location /status/ {
-        # That takes so many lines in acess log for statuses, so it is better to disable access for that url
-        access_log if=$abnormal;
+        # That takes so many lines in acess log for statuses,
+        # so it is better to disable access for that url
+        access_log /var/log/nginx/access.log combined if=$abnormal;
         proxy_pass http://127.0.0.1:8020/;
         proxy_set_header Host $http_host;
     }


### PR DESCRIPTION
There is a misconfiguration in adcm.conf which
lead to pass access logs to /var/log/nginx/if=0.