### PR TITLE
There is a strange issue with lazy fixture

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ allure-pytest==2.5.4
 delayed_assert
 docker
 jsonschema
-pytest
+pytest==5.3.2
 pytest-lazy-fixture
 pytest-xdist  # pytest distributed testing plugin (for parallel tests)
 pyyaml


### PR DESCRIPTION
Supposed it is a bug in latest 5.3.3 pytest.

Failed: ScopeMismatch: You tried to access the 'function' scoped fixture 'expected_args' with a 'module' scoped request object, involved factories
tests/functional/test_backend_filtering.py:26:  def cluster_bundles(sdk_client_ms:adcm_client.objects.ADCMClient)
../usr/local/lib/python3.6/dist-packages/_pytest/fixtures.py:297:  def get_direct_param_fixture_func(request)