### PR TITLE
ADCM-270 Unfreeze markdown in requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arenadata/adcmbase:20200130192319
+FROM arenadata/adcmbase:20200203174702
 
 COPY . /adcm/
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Set number of threads
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 ADCMBASE_IMAGE ?= arenadata/adcmbase
-ADCMBASE_TAG ?= 20200130192319
+ADCMBASE_TAG ?= 20200203174702
 
 
 # Default target

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ djangorestframework
 social-auth-app-django
 git+git://github.com/arenadata/django-generate-secret-key.git
 jinja2
-markdown==2.6.11 # Due to bug in djangorestframework
+markdown
 pyyaml
 toml
 uwsgi


### PR DESCRIPTION
Upstream issue https://github.com/encode/django-rest-framework/issues/6203
was fixed so I think we can remove that restriction.