### PR TITLE
Add nocache option to static files

### DIFF
--- a/conf/nginx/adcm.conf
+++ b/conf/nginx/adcm.conf
@@ -32,6 +32,9 @@ server {
     root /adcm/wwwroot;
 
     location / {
+        if ($arg_nocache) {
+            add_header Cache-Control no-cache;
+        }
         try_files $uri $uri/ /index.html;
     }
 


### PR DESCRIPTION
That commit force nginx to add nocache header to any static
file from wwwroot if we there is an nocache get paremeter
in uri. That is usefull for UI to contol caching.