### PR TITLE
ADCM-1166 Fixup wrong context for service_name

### DIFF
--- a/tests/functional/test_plugins_config.py
+++ b/tests/functional/test_plugins_config.py
@@ -171,6 +171,30 @@ def test_service_config_from_cluster_by_name(cluster_bundle: Bundle, keys_cluste
         assert_cluster_config(cluster_bundle, expected_state)
 
 
+def test_service_config_from_service_by_name(cluster_bundle: Bundle, keys_clusters_services):
+    expected_state = copy.deepcopy(INITIAL_CLUSTERS_CONFIG)
+    assert_cluster_config(cluster_bundle, expected_state)
+
+    for key, cname, sname in keys_clusters_services:
+        service = cluster_bundle.cluster(name=cname).service(name=sname)
+        service.action(name='service_name_' + sname + '_' + key).run().try_wait()
+        expected_state[cname]["services"][sname][key] = NEW_VALUES[key]
+        assert_cluster_config(cluster_bundle, expected_state)
+
+
+def test_another_service_from_service_by_name(cluster_bundle: Bundle, keys_clusters_services):
+    expected_state = copy.deepcopy(INITIAL_CLUSTERS_CONFIG)
+    assert_cluster_config(cluster_bundle, expected_state)
+
+    for key, cname, sname in keys_clusters_services:
+        if sname == "Second":
+            continue
+        second = cluster_bundle.cluster(name=cname).service(name='Second')
+        result = second.action(name='service_name_' + sname + '_' + key).run().wait()
+        assert result == "failed", "Job expected to be failed"
+        assert_cluster_config(cluster_bundle, expected_state)
+
+
 def test_service_config(cluster_bundle: Bundle, keys_clusters_services):
     expected_state = copy.deepcopy(INITIAL_CLUSTERS_CONFIG)
     assert_cluster_config(cluster_bundle, expected_state)

--- a/tests/functional/test_plugins_config_data/cluster/config.yaml
+++ b/tests/functional/test_plugins_config_data/cluster/config.yaml
@@ -273,6 +273,7 @@
       <<: *service_action
       params:
         ansible_tags: list
+    <<: *cluster_actions
 
 
 
@@ -282,6 +283,8 @@
   name: Second
   version: 1
 
-  actions: *service_actions
+  actions:
+    <<: *service_actions
+    <<: *cluster_actions
 
   config: *config

--- a/tests/functional/test_plugins_state.py
+++ b/tests/functional/test_plugins_state.py
@@ -71,6 +71,28 @@ def test_change_service_state_by_name(cluster_bundle: Bundle):
     assert_cluster_service_states(cluster_bundle, expected_state)
 
 
+def test_change_service_state_by_name_from_service(cluster_bundle: Bundle):
+    expected_state = copy.deepcopy(INITIAL_CLUSTERS_STATE)
+    assert_cluster_service_states(cluster_bundle, expected_state)
+
+    second = cluster_bundle.cluster(name='first').service(name='Second')
+
+    second.action(name='set_second_service').run().try_wait()
+    expected_state['first']['services']['Second'] = 'state2'
+    assert_cluster_service_states(cluster_bundle, expected_state)
+
+
+def test_change_service_state_by_name_from_another_service(cluster_bundle: Bundle):
+    expected_state = copy.deepcopy(INITIAL_CLUSTERS_STATE)
+    assert_cluster_service_states(cluster_bundle, expected_state)
+
+    second = cluster_bundle.cluster(name='first').service(name='Second')
+
+    result = second.action(name='set_first_service').run().wait()
+    assert result == "failed", "Job expected to be failed"
+    assert_cluster_service_states(cluster_bundle, expected_state)
+
+
 def test_change_service_state(cluster_bundle: Bundle):
     expected_state = copy.deepcopy(INITIAL_CLUSTERS_STATE)
     assert_cluster_service_states(cluster_bundle, expected_state)

--- a/tests/functional/test_plugins_state_data/cluster/config.yaml
+++ b/tests/functional/test_plugins_state_data/cluster/config.yaml
@@ -44,6 +44,20 @@
       states:
         available: any
 
+    set_first_service:
+      type: job
+      script_type: ansible
+      script: set_first_service.yaml
+      states:
+        available: any
+
+    set_second_service:
+      type: job
+      script_type: ansible
+      script: set_second_service.yaml
+      states:
+        available: any
+
 - type: service
   name: Second
   version: 1


### PR DESCRIPTION
Last changes in e7476d8 has some regressions with context restriction in a number of ansible plugins.

It was a bug before ADCM-1143, that allow to use service_name in service context. While docs dissallow that, bundle writers used that.

That code allows to user service_name in service context.