### PR TITLE
ADCM-1229 apt_rpm: package as a list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arenadata/adcmbase:20200331164727
+FROM arenadata/adcmbase:20200415202034
 
 COPY . /adcm/
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Set number of threads
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
 ADCMBASE_IMAGE ?= arenadata/adcmbase
-ADCMBASE_TAG ?= 20200331164727
+ADCMBASE_TAG ?= 20200415202034
 
 
 # Default target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # ansible==2.8.3
-git+https://github.com/arenadata/ansible.git@v2.8.8-p3
+git+https://github.com/arenadata/ansible.git@v2.8.8-p4
 coreapi
 django
 django-cors-headers


### PR DESCRIPTION
That image bump adds patch to ansible for changing
package parameter type to list in apt_rpm module.

This patch was prepared by @amleshkov (lam@arenadata.io)
for community.general.
See https://github.com/ansible-collections/community.general/pull/169