### PR TITLE
Change timeouts in nginx config

### DIFF
--- a/conf/nginx/adcm.conf
+++ b/conf/nginx/adcm.conf
@@ -28,6 +28,7 @@ server {
 
     client_max_body_size 100M;
     client_body_temp_path /adcm/data/tmp/nginx_client_temp 1 2;
+    client_body_timeout 300s;
 
     root /adcm/wwwroot;
 
@@ -40,6 +41,8 @@ server {
 
     location /api {
         uwsgi_pass  django;
+        uwsgi_read_timeout 300s;
+        uwsgi_send_timeout 300s;
         include     /adcm/conf/nginx/uwsgi_params;
         proxy_set_header Host $http_host;
     }


### PR DESCRIPTION
While uploading large bundles we get 504 error.
Added timeout values for clien_body_timeout and api uwsgi_read_timeout