### PR TITLE
ADCM-1331 Fixup ui config test for password

### DIFF
--- a/tests/ui_tests/app/configuration.py
+++ b/tests/ui_tests/app/configuration.py
@@ -42,15 +42,22 @@ class Configuration(BasePage):
         :return:
         """
         current_value = self.get_field_value_by_type(field, field_type)
-        if field_type == 'file':
-            expected_value = 'test'
-        if field_type == 'map':
-            map_config = self.get_map_field_config(field)
-            assert set(map_config.keys()) == set(map_config.keys())
-            assert set(map_config.values()) == set(map_config.values())
+        if field_type == 'password':
+            # In case of password we have no raw password in API after writing.
+            if expected_value is not None and expected_value != "":
+                assert current_value is not None, "Password field expected to be filled"
+            else:
+                assert current_value is None or current_value == "", "Password have to be empty"
         else:
-            err_message = "Default value wrong. Current value {}".format(current_value)
-            assert current_value == expected_value, err_message
+            if field_type == 'file':
+                expected_value = 'test'
+            if field_type == 'map':
+                map_config = self.get_map_field_config(field)
+                assert set(map_config.keys()) == set(map_config.keys())
+                assert set(map_config.values()) == set(map_config.values())
+            else:
+                err_message = "Default value wrong. Current value {}".format(current_value)
+                assert current_value == expected_value, err_message
 
     def assert_alerts_presented(self, field_type):
         """Check that frontend errors presented on screen and error type in text


### PR DESCRIPTION
There is no way for us to see password unencrypted anymore.

After this commit we stoped to check password field for equal,
because there is no way to read password back unecrypted.

We compare for empty only.