### PR TITLE
UI: add space after VERSION at footer

### DIFF
--- a/web/src/app/app.component.ts
+++ b/web/src/app/app.component.ts
@@ -25,7 +25,7 @@ import { filter } from 'rxjs/operators';
     <footer>
       <div>
         <span class="left">
-          <span>VERSION:</span>
+          <span>VERSION: </span>
           <a target="_blank" href="https://docs.arenadata.io/adcm/notes.html#{{ versionData.version }}">{{ versionData.version }}-{{ versionData.commit_id }}</a>
         </span>
         <span>ARENADATA &copy; {{ currentYear }}</span>


### PR DESCRIPTION
Without a space VERSION:2020.... looks ugly.
Hope it will brake nothing.