### PR TITLE
Simplify url config patterns with include

### DIFF
--- a/python/api/serializers.py
+++ b/python/api/serializers.py
@@ -309,7 +309,7 @@ class AdcmSerializer(serializers.Serializer):
 class AdcmDetailSerializer(AdcmSerializer):
     prototype_version = serializers.SerializerMethodField()
     bundle_id = serializers.SerializerMethodField()
-    config = ConfigURL(view_name='adcm-config')
+    config = ConfigURL(view_name='config')
 
     def get_prototype_version(self, obj):
         return obj.prototype.version
@@ -353,7 +353,7 @@ class ProviderDetailSerializer(ProviderSerializer):
     license = serializers.SerializerMethodField()
     bundle_id = serializers.SerializerMethodField()
     prototype = hlink('provider-type-details', 'prototype_id', 'prototype_id')
-    config = ConfigURL(view_name='provider-config')
+    config = ConfigURL(view_name='config')
     action = hlink('provider-action', 'id', 'provider_id')
     upgrade = hlink('provider-upgrade', 'id', 'provider_id')
     host = hlink('provider-host', 'id', 'provider_id')
@@ -959,19 +959,19 @@ class HistoryCurrentPreviousConfigSerializer(serializers.Serializer):
 
     def get_history(self, obj):
         object_type = obj.prototype.type
-        view_name = f'{object_type}-config-history'
+        view_name = 'config-history'
         return ConfigURL(read_only=True, view_name=view_name).get_url(
             obj, view_name, self.context['request'], format=None)
 
     def get_current(self, obj):
         object_type = obj.prototype.type
-        view_name = f'{object_type}-config-current'
+        view_name = 'config-current'
         return ConfigURL(read_only=True, view_name=view_name).get_url(
             obj, view_name, self.context['request'], format=None)
 
     def get_previous(self, obj):
         object_type = obj.prototype.type
-        view_name = f'{object_type}-config-previous'
+        view_name = 'config-previous'
         return ConfigURL(read_only=True, view_name=view_name).get_url(
             obj, view_name, self.context['request'], format=None)
 
@@ -1021,6 +1021,6 @@ class ConfigHistorySerializer(ObjectConfigSerializer):
 
     def get_url(self, obj):
         object_type = obj.object_type
-        view_name = f'{object_type}-config-history-version'
+        view_name = 'config-history-version'
         return ConfigVersionURL(read_only=True, view_name=view_name).get_url(
             obj, view_name, self.context['request'], format=None)

--- a/python/api/urls.py
+++ b/python/api/urls.py
@@ -35,6 +35,37 @@ HOST_CONFIG = HOST + 'config/'
 SERVICE_CONFIG = CLUSTER + SERVICE + 'config/'
 
 
+urlpatterns_config = [
+    path(
+        '',
+        views.ConfigView.as_view(),
+        name='config'
+    ),
+    path(
+        'history/',
+        views.ConfigHistoryView.as_view(),
+        name='config-history'
+    ),
+    path(
+        'history/<int:version>/',
+        views.ConfigHistoryVersionView.as_view(),
+        name='config-history-version'
+    ),
+    path(
+        'previous/',
+        views.ConfigPreviousView.as_view(),
+        {'version': 'previous'},
+        name='config-previous'
+    ),
+    path(
+        'current/',
+        views.ConfigCurrentView.as_view(),
+        {'version': 'current'},
+        name='config-current'
+    ),
+]
+
+
 urlpatterns = [
     path('info/', views.ADCMInfo.as_view(), name='adcm-info'),
     path('token/', views.GetAuthToken.as_view(), name='token'),
@@ -334,35 +365,8 @@ urlpatterns = [
 
     path(
         ADCM_CONFIG,
-        views.ConfigView.as_view(),
-        {'object_type': 'adcm'},
-        name='adcm-config'
-    ),
-    path(
-        ADCM_CONFIG + 'history/',
-        views.ConfigHistoryView.as_view(),
-        {'object_type': 'adcm'},
-        name='adcm-config-history'
-    ),
-    path(
-        ADCM_CONFIG + 'history/<int:version>/',
-        views.ConfigHistoryVersionView.as_view(),
-        {'object_type': 'adcm'},
-        name='adcm-config-history-version'
-    ),
-    path(
-        ADCM_CONFIG + 'previous/',
-        views.ConfigPreviousView.as_view(),
-        {'object_type': 'adcm',
-         'version': 'previous'},
-        name='adcm-config-previous'
-    ),
-    path(
-        ADCM_CONFIG + 'current/',
-        views.ConfigCurrentView.as_view(),
-        {'object_type': 'adcm',
-         'version': 'current'},
-        name='adcm-config-current'
+        include(urlpatterns_config),
+        {'object_type': 'adcm'}
     ),
 
     path('adcm/<int:adcm_id>/action/', views.ADCMActionList.as_view(), name='adcm-action'),
@@ -405,41 +409,8 @@ urlpatterns = [
 
     path(
         PROVIDER_CONFIG,
-        views.ConfigView.as_view(),
-        {'object_type': 'provider'},
-        name='provider-config'
-    ),
-    path(
-        PROVIDER_CONFIG + 'history/',
-        views.ConfigHistoryView.as_view(),
-        {'object_type': 'provider'},
-        name='provider-config-history'
-    ),
-    path(
-        PROVIDER_CONFIG + 'history/<int:version>/',
-        views.ConfigHistoryVersionView.as_view(),
-        {'object_type': 'provider'},
-        name='provider-config-history-version'
-    ),
-    path(
-        PROVIDER_CONFIG + 'history/<int:version>/restore/',
-        views.ConfigHistoryRestoreView.as_view(),
-        {'object_type': 'provider'},
-        name='provider-config-history-version-restore'
-    ),
-    path(
-        PROVIDER_CONFIG + 'previous/',
-        views.ConfigPreviousView.as_view(),
-        {'object_type': 'provider',
-         'version': 'previous'},
-        name='provider-config-previous'
-    ),
-    path(
-        PROVIDER_CONFIG + 'current/',
-        views.ConfigCurrentView.as_view(),
-        {'object_type': 'provider',
-         'version': 'current'},
-        name='provider-config-current'
+        include(urlpatterns_config),
+        {'object_type': 'provider'}
     ),
 
     path('host/', views.HostList.as_view(), name='host'),


### PR DESCRIPTION
There is a way to reuse url and view names. See documentation at
https://docs.djangoproject.com/en/3.1/topics/http/urls/#passing-extra-options-to-include

In that sample I use the same patterns and view for two objects:
ADCM and Provider. I beleave it is possible to do so for Cluster,
Service and Host too.

After changes I checked url on API and schema over client. Everything
is fine.