### PR TITLE
locks refactoring

### DIFF
--- a/python/cm/job.py
+++ b/python/cm/job.py
@@ -32,7 +32,7 @@ from cm import api, issue, inventory, adcm_config, variant
 from cm.adcm_config import obj_ref, process_file_type
 from cm.errors import raise_AdcmEx as err
 from cm.inventory import get_obj_config, process_config_and_attr
-from cm.lock import lock_objects, unlock_objects  # , set_task_status, set_job_status
+from cm.lock import lock_objects, unlock_objects
 from cm.logger import log
 from cm.models import (
     Cluster, Action, SubAction, TaskLog, JobLog, CheckLog, Host, ADCM,
@@ -96,6 +96,7 @@ def check_action_hosts(action, cluster, provider, hosts):
 @transaction.atomic
 def prepare_task(action, obj, selector, conf, attr, spec, old_hc, delta, host_map, cluster,   # pylint: disable=too-many-locals
                  hosts, event, verbose):
+    DummyData.objects.filter(id=1).update(date=timezone.now())
     lock_objects(obj, event)
 
     if not attr:
@@ -632,6 +633,16 @@ def restore_hc(task, action, status):
     api.save_hc(cluster, host_comp_list)
 
 
+def get_job_cluster(job):
+    """Get Job's cluster for unlocking in case linked objects were somehow deleted"""
+    if not job:
+        return
+
+    selector = job.selector
+    if 'cluster' in selector:
+        return Cluster.objects.get(id=selector['cluster'])
+
+
 def finish_task(task, job, status):
     action = Action.objects.get(id=task.action_id)
     obj = get_task_obj(action.prototype.type, task.object_id)
@@ -641,7 +652,7 @@ def finish_task(task, job, status):
         DummyData.objects.filter(id=1).update(date=timezone.now())
         if state is not None:
             set_action_state(action, task, obj, state)
-        unlock_objects(obj, event, job)
+        unlock_objects(obj or get_job_cluster(job), event)
         restore_hc(task, action, status)
         set_task_status(task, status, event)
     event.send_state()

--- a/python/cm/lock.py
+++ b/python/cm/lock.py
@@ -12,34 +12,18 @@
 
 # pylint: disable=too-many-branches,
 
-from django.utils import timezone
-
 import cm.config as config
 from cm import api
 from cm.adcm_config import obj_ref
 from cm.logger import log
 from cm.models import (
-    ServiceComponent,
-    Host,
-    ClusterObject,
     ADCM,
     Cluster,
+    ClusterObject,
+    Host,
     HostProvider,
-    TaskLog,
-    JobLog,
+    ServiceComponent,
 )
-
-
-def set_task_status(task, status, event):
-    task.status = status
-    task.finish_date = timezone.now()
-    task.save()
-    event.set_task_status(task.id, status)
-
-
-def set_job_status(job_id, status, event, pid=0):
-    JobLog.objects.filter(id=job_id).update(status=status, pid=pid, finish_date=timezone.now())
-    event.set_job_status(job_id, status)
 
 
 def lock_obj(obj, event):
@@ -174,7 +158,3 @@ def unlock_all(event):
         unlock_objects(obj, event)
     for obj in Host.objects.filter(state=config.Job.LOCKED):
         unlock_objects(obj, event)
-    for task in TaskLog.objects.filter(status=config.Job.RUNNING):
-        set_task_status(task, config.Job.ABORTED, event)
-    for job in JobLog.objects.filter(status=config.Job.RUNNING):
-        set_job_status(job.id, config.Job.ABORTED, event)

--- a/python/cm/lock.py
+++ b/python/cm/lock.py
@@ -26,7 +26,7 @@ from cm.models import (
 )
 
 
-def lock_obj(obj, event):
+def _lock_obj(obj, event):
     stack = obj.stack
 
     if not stack:
@@ -39,7 +39,7 @@ def lock_obj(obj, event):
     api.set_object_state(obj, config.Job.LOCKED, event)
 
 
-def unlock_obj(obj, event):
+def _unlock_obj(obj, event):
     if obj.stack:
         stack = obj.stack
     else:
@@ -57,40 +57,40 @@ def unlock_obj(obj, event):
 
 def lock_objects(obj, event):
     if isinstance(obj, ServiceComponent):
-        lock_obj(obj, event)
-        lock_obj(obj.service, event)
-        lock_obj(obj.cluster, event)
+        _lock_obj(obj, event)
+        _lock_obj(obj.service, event)
+        _lock_obj(obj.cluster, event)
         for host in Host.objects.filter(cluster=obj.cluster):
-            lock_obj(host, event)
+            _lock_obj(host, event)
     elif isinstance(obj, ClusterObject):
-        lock_obj(obj, event)
-        lock_obj(obj.cluster, event)
+        _lock_obj(obj, event)
+        _lock_obj(obj.cluster, event)
         for sc in ServiceComponent.objects.filter(service=obj):
-            lock_obj(sc, event)
+            _lock_obj(sc, event)
         for host in Host.objects.filter(cluster=obj.cluster):
-            lock_obj(host, event)
+            _lock_obj(host, event)
     elif isinstance(obj, Host):
-        lock_obj(obj, event)
+        _lock_obj(obj, event)
         if obj.cluster:
-            lock_obj(obj.cluster, event)
+            _lock_obj(obj.cluster, event)
             for service in ClusterObject.objects.filter(cluster=obj.cluster):
-                lock_obj(service, event)
+                _lock_obj(service, event)
             for sc in ServiceComponent.objects.filter(cluster=obj.cluster):
-                lock_obj(sc, event)
+                _lock_obj(sc, event)
     elif isinstance(obj, HostProvider):
-        lock_obj(obj, event)
+        _lock_obj(obj, event)
         for host in Host.objects.filter(provider=obj):
-            lock_obj(host, event)
+            _lock_obj(host, event)
     elif isinstance(obj, ADCM):
-        lock_obj(obj, event)
+        _lock_obj(obj, event)
     elif isinstance(obj, Cluster):
-        lock_obj(obj, event)
+        _lock_obj(obj, event)
         for service in ClusterObject.objects.filter(cluster=obj):
-            lock_obj(service, event)
+            _lock_obj(service, event)
         for sc in ServiceComponent.objects.filter(cluster=obj):
-            lock_obj(sc, event)
+            _lock_obj(sc, event)
         for host in Host.objects.filter(cluster=obj):
-            lock_obj(host, event)
+            _lock_obj(host, event)
     else:
         log.warning('lock_objects: unknown object type: %s', obj)
 
@@ -107,40 +107,40 @@ def unlock_deleted_objects(job, event):
 
 def unlock_objects(obj, event, job=None):
     if isinstance(obj, ServiceComponent):
-        unlock_obj(obj, event)
-        unlock_obj(obj.service, event)
-        unlock_obj(obj.cluster, event)
+        _unlock_obj(obj, event)
+        _unlock_obj(obj.service, event)
+        _unlock_obj(obj.cluster, event)
         for host in Host.objects.filter(cluster=obj.cluster):
-            unlock_obj(host, event)
+            _unlock_obj(host, event)
     elif isinstance(obj, ClusterObject):
-        unlock_obj(obj, event)
-        unlock_obj(obj.cluster, event)
+        _unlock_obj(obj, event)
+        _unlock_obj(obj.cluster, event)
         for sc in ServiceComponent.objects.filter(service=obj):
-            unlock_obj(sc, event)
+            _unlock_obj(sc, event)
         for host in Host.objects.filter(cluster=obj.cluster):
-            unlock_obj(host, event)
+            _unlock_obj(host, event)
     elif isinstance(obj, Host):
-        unlock_obj(obj, event)
+        _unlock_obj(obj, event)
         if obj.cluster:
-            unlock_obj(obj.cluster, event)
+            _unlock_obj(obj.cluster, event)
             for service in ClusterObject.objects.filter(cluster=obj.cluster):
-                unlock_obj(service, event)
+                _unlock_obj(service, event)
             for sc in ServiceComponent.objects.filter(cluster=obj.cluster):
-                unlock_obj(sc, event)
+                _unlock_obj(sc, event)
     elif isinstance(obj, HostProvider):
-        unlock_obj(obj, event)
+        _unlock_obj(obj, event)
         for host in Host.objects.filter(provider=obj):
-            unlock_obj(host, event)
+            _unlock_obj(host, event)
     elif isinstance(obj, ADCM):
-        unlock_obj(obj, event)
+        _unlock_obj(obj, event)
     elif isinstance(obj, Cluster):
-        unlock_obj(obj, event)
+        _unlock_obj(obj, event)
         for service in ClusterObject.objects.filter(cluster=obj):
-            unlock_obj(service, event)
+            _unlock_obj(service, event)
         for sc in ServiceComponent.objects.filter(cluster=obj):
-            unlock_obj(sc, event)
+            _unlock_obj(sc, event)
         for host in Host.objects.filter(cluster=obj):
-            unlock_obj(host, event)
+            _unlock_obj(host, event)
     elif obj is None:
         unlock_deleted_objects(job, event)
     else:

--- a/python/cm/tests_job.py
+++ b/python/cm/tests_job.py
@@ -9,6 +9,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# pylint: disable=protected-access
+
 import os
 from unittest.mock import patch, Mock, call
 
@@ -166,12 +169,12 @@ class TestJob(TestCase):
         for obj, check_assert in data:
             with self.subTest(obj=obj):
 
-                lock_module.unlock_obj(obj, event)
+                lock_module._unlock_obj(obj, event)
 
                 check_assert()
                 mock_set_object_state.reset_mock()
 
-    @patch('cm.lock.unlock_obj')
+    @patch('cm.lock._unlock_obj')
     def test_unlock_objects(self, mock_unlock_obj):
         bundle = models.Bundle.objects.create()
         prototype = models.Prototype.objects.create(bundle=bundle)

--- a/python/cm/tests_job.py
+++ b/python/cm/tests_job.py
@@ -42,7 +42,7 @@ class TestJob(TestCase):
         pid = 10
         event = Mock()
 
-        lock_module.set_job_status(job.id, status, event, pid)
+        job_module.set_job_status(job.id, status, event, pid)
 
         job = models.JobLog.objects.get(id=job.id)
         self.assertEqual(job.status, status)
@@ -56,7 +56,7 @@ class TestJob(TestCase):
             action_id=1, object_id=1,
             start_date=timezone.now(), finish_date=timezone.now())
 
-        lock_module.set_task_status(task, config.Job.RUNNING, event)
+        job_module.set_task_status(task, config.Job.RUNNING, event)
 
         self.assertEqual(task.status, config.Job.RUNNING)
         event.set_task_status.assert_called_once_with(task.id, config.Job.RUNNING)

--- a/python/cm/tests_runner.py
+++ b/python/cm/tests_runner.py
@@ -138,7 +138,7 @@ class TestJobRunner(TestCase):
         _mock_open.assert_called_once_with(file_name)
         self.assertDictEqual(conf, {})
 
-    @patch('cm.lock.set_job_status')
+    @patch('cm.job.set_job_status')
     def test_set_job_status(self, mock_set_job_status):
         mock_set_job_status.return_value = None
         code = job_runner.set_job_status(1, 0, 1, None)
@@ -157,7 +157,7 @@ class TestJobRunner(TestCase):
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-arguments
     @patch('job_runner.Event')
-    @patch('cm.lock.set_job_status')
+    @patch('cm.job.set_job_status')
     @patch('sys.exit')
     @patch('job_runner.set_job_status')
     @patch('subprocess.Popen')

--- a/python/cm/unit_tests/utils.py
+++ b/python/cm/unit_tests/utils.py
@@ -38,6 +38,16 @@ def gen_prototype(bundle: models.Bundle, proto_type):
     )
 
 
+def gen_adcm():
+    """Generate or return existing the only ADCM object"""
+    try:
+        return models.ADCM.objects.get(name='ADCM')
+    except models.ObjectDoesNotExist:
+        bundle = gen_bundle()
+        prototype = gen_prototype(bundle, 'adcm')
+        return models.ADCM.objects.create(name='ADCM', prototype=prototype)
+
+
 def gen_cluster(name='', bundle=None, prototype=None):
     """Generate cluster from specified prototype"""
     if not prototype:
@@ -87,7 +97,7 @@ def gen_host(provider, cluster=None, fqdn='', bundle=None, prototype=None):
     """Generate host for specified cluster, provider, and prototype"""
     if not prototype:
         bundle = bundle or gen_bundle()
-        prototype = gen_prototype(bundle, 'service')
+        prototype = gen_prototype(bundle, 'host')
     return models.Host.objects.create(
         **_gen_name(fqdn, 'fqdn'),
         cluster=cluster,

--- a/python/init_db.py
+++ b/python/init_db.py
@@ -22,6 +22,7 @@ from cm.logger import log
 from cm.models import UserProfile, DummyData, CheckLog, GroupCheckLog
 from cm.bundle import load_adcm
 from cm.config import SECRETS_FILE
+from cm.job import abort_all
 from cm.lock import unlock_all
 from cm.status_api import Event
 
@@ -71,6 +72,7 @@ def init():
         UserProfile.objects.create(login='admin')
     create_status_user()
     event = Event()
+    abort_all(event)
     unlock_all(event)
     clear_temp_tables()
     event.send_state()

--- a/python/job_runner.py
+++ b/python/job_runner.py
@@ -42,13 +42,13 @@ def read_config(job_id):
 
 def set_job_status(job_id, ret, pid, event):
     if ret == 0:
-        cm.lock.set_job_status(job_id, config.Job.SUCCESS, event, pid)
+        cm.job.set_job_status(job_id, config.Job.SUCCESS, event, pid)
         return 0
     elif ret == -15:
-        cm.lock.set_job_status(job_id, config.Job.ABORTED, event, pid)
+        cm.job.set_job_status(job_id, config.Job.ABORTED, event, pid)
         return 15
     else:
-        cm.lock.set_job_status(job_id, config.Job.FAILED, event, pid)
+        cm.job.set_job_status(job_id, config.Job.FAILED, event, pid)
         return ret
 
 
@@ -116,7 +116,7 @@ def run_ansible(job_id):
 
     proc = subprocess.Popen(cmd, env=env_configuration(conf), stdout=out_file, stderr=err_file)
     log.info("job #%s run cmd: %s", job_id, ' '.join(cmd))
-    cm.lock.set_job_status(job_id, config.Job.RUNNING, event, proc.pid)
+    cm.job.set_job_status(job_id, config.Job.RUNNING, event, proc.pid)
     event.send_state()
     log.info("run ansible job #%s, pid %s, playbook %s", job_id, proc.pid, playbook)
     ret = proc.wait()


### PR DESCRIPTION
- minor code reorder to group functions with similar responsibility
- rename object lock/unlock functions to hide realization from direct usage
- replace lock/unlock hierarchy function with generalized code
- TODO: locking mechanics remains the same for now