### PR TITLE
Set Codeowners of the `functional` and `ui_tests` to @arenadata/python-qa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 
-/tests/functional/ @arenadata/qa
-/tests/ui_tests/ @arenadata/qa
+/tests/functional/ @arenadata/python-qa
+/tests/ui_tests/ @arenadata/python-qa


### PR DESCRIPTION
Set Codeowners of the `functional` and `ui_tests` to @arenadata/python-qa so that Java QA will not be disturbed with the review requests