### PR TITLE
ADCM-1949 Update CRUD tests for groups

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,3 +17,4 @@ requests-toolbelt
 selenium
 multipledispatch
 rstr
+genson

--- a/tests/api/steps/asserts.py
+++ b/tests/api/steps/asserts.py
@@ -1,9 +1,20 @@
 """Some asserts with allure steps"""
 import json
+from dataclasses import field, dataclass
 from http import HTTPStatus
 
 import allure
 from requests import Response
+
+
+@dataclass
+class ExpectedBody:
+    """
+    In POST PATCH PUT cases we check only changed or created fields
+    and response body contains other fields (without checking their values)
+    """
+    fields: list = field(default_factory=list)
+    fields_values: dict = field(default_factory=dict)
 
 
 class BodyAssertionError(AssertionError):
@@ -19,20 +30,39 @@ def status_code_should_be(response: Response, status_code=HTTPStatus.OK):
 
 
 @allure.step("Response body should be")
-def body_should_be(response: Response, expected_body=None):
+def body_should_be(response: Response, expected_body: ExpectedBody):
     """Assert response body and attach it"""
-    actual_body = response.json()
-    allure.attach(
-        json.dumps(expected_body, indent=2),
-        name='Expected body',
-        attachment_type=allure.attachment_type.JSON,
-    )
-    allure.attach(
-        json.dumps(actual_body, indent=2),
-        name='Actual body',
-        attachment_type=allure.attachment_type.JSON,
-    )
-    try:
-        assert actual_body == expected_body, "Response body assertion failed!"
-    except AssertionError as error:
-        raise BodyAssertionError(error) from error
+    actual_body: dict = response.json()
+    if expected_body.fields:
+        with allure.step("Body should contains fields"):
+            try:
+                assert set(actual_body.keys()) == set(expected_body.fields), (
+                    f"Response body fields assertion failed! "
+                    f"Body fields are not as expected: {', '.join(expected_body.fields)}"
+                )
+            except AssertionError as error:
+                raise BodyAssertionError(error) from error
+
+    if expected_body.fields_values:
+        with allure.step("Fields values should be"):
+            actual_fields_values = {
+                key: value
+                for key, value in actual_body.items()
+                if key in expected_body.fields_values
+            }
+            allure.attach(
+                json.dumps(expected_body.fields_values, indent=2),
+                name='Expected fields values',
+                attachment_type=allure.attachment_type.JSON,
+            )
+            allure.attach(
+                json.dumps(actual_fields_values or actual_body, indent=2),
+                name='Actual fields values',
+                attachment_type=allure.attachment_type.JSON,
+            )
+            try:
+                assert actual_fields_values == expected_body.fields_values, (
+                    "Response fields values assertion failed!"
+                )
+            except AssertionError as error:
+                raise BodyAssertionError(error) from error

--- a/tests/api/steps/asserts.py
+++ b/tests/api/steps/asserts.py
@@ -6,6 +6,8 @@ from http import HTTPStatus
 import allure
 from requests import Response
 
+from tests.api.utils.tools import NotSet
+
 
 @dataclass
 class ExpectedBody:
@@ -13,8 +15,7 @@ class ExpectedBody:
     In POST PATCH PUT cases we check only changed or created fields
     and response body contains other fields (without checking their values)
     """
-    fields: list = field(default_factory=list)
-    fields_values: dict = field(default_factory=dict)
+    fields: dict = field(default_factory=dict)
 
 
 class BodyAssertionError(AssertionError):
@@ -33,25 +34,29 @@ def status_code_should_be(response: Response, status_code=HTTPStatus.OK):
 def body_should_be(response: Response, expected_body: ExpectedBody):
     """Assert response body and attach it"""
     actual_body: dict = response.json()
-    if expected_body.fields:
-        with allure.step("Body should contains fields"):
-            try:
-                assert set(actual_body.keys()) == set(expected_body.fields), (
-                    f"Response body fields assertion failed! "
-                    f"Body fields are not as expected: {', '.join(expected_body.fields)}"
-                )
-            except AssertionError as error:
-                raise BodyAssertionError(error) from error
+    expected_fields_values = {
+        key: value
+        for key, value in expected_body.fields.items()
+        if not isinstance(value, NotSet)
+    }
+    with allure.step("Body should contains fields"):
+        try:
+            assert set(actual_body.keys()) == set(expected_body.fields.keys()), (
+                f"Response body fields assertion failed! "
+                f"Body fields are not as expected: {', '.join(expected_body.fields)}"
+            )
+        except AssertionError as error:
+            raise BodyAssertionError(error) from error
 
-    if expected_body.fields_values:
+    if expected_fields_values:
         with allure.step("Fields values should be"):
             actual_fields_values = {
                 key: value
                 for key, value in actual_body.items()
-                if key in expected_body.fields_values
+                if key in expected_fields_values
             }
             allure.attach(
-                json.dumps(expected_body.fields_values, indent=2),
+                json.dumps(expected_fields_values, indent=2),
                 name='Expected fields values',
                 attachment_type=allure.attachment_type.JSON,
             )
@@ -61,7 +66,7 @@ def body_should_be(response: Response, expected_body: ExpectedBody):
                 attachment_type=allure.attachment_type.JSON,
             )
             try:
-                assert actual_fields_values == expected_body.fields_values, (
+                assert actual_fields_values == expected_fields_values, (
                     "Response fields values assertion failed!"
                 )
             except AssertionError as error:

--- a/tests/api/test_body/test_patch.py
+++ b/tests/api/test_body/test_patch.py
@@ -13,7 +13,7 @@ from tests.api.testdata.generators import (
     TestDataWithPreparedBody,
 )
 from tests.api.testdata.db_filler import DbFiller
-from tests.api.utils.api_objects import ADCMTestApiWrapper
+from tests.api.utils.api_objects import ADCMTestApiWrapper, ExpectedBody
 
 from tests.api.utils.types import get_fields
 from tests.api.utils.methods import Methods
@@ -42,7 +42,6 @@ def prepare_patch_body_data(request, adcm_api_fs: ADCMTestApiWrapper):
             if (
                 field.name in prepared_field_values
             ) and not prepared_field_values[field.name].drop_key:
-
                 current_field_value = full_item[field.name]
                 if prepared_field_values[field.name].unchanged_value is False:
                     changed_field_value = changed_fields.get(field.name, None)
@@ -68,6 +67,12 @@ def test_patch_body_positive(prepare_patch_body_data):
     """
     adcm, test_data_list = prepare_patch_body_data
     for test_data in test_data_list:
+        # Set expected response fields
+        test_data.response.body = ExpectedBody()
+        for field in get_fields(test_data.request.endpoint.data_class):
+            test_data.response.body.fields.append(field.name)
+            if expected_field_value := test_data.request.data.get(field.name):
+                test_data.response.body.fields_values[field.name] = expected_field_value
         with allure.step(f'Assert - {test_data.description}'):
             adcm.exec_request(request=test_data.request, expected_response=test_data.response)
 

--- a/tests/api/test_body/test_patch.py
+++ b/tests/api/test_body/test_patch.py
@@ -14,6 +14,7 @@ from tests.api.testdata.generators import (
 )
 from tests.api.testdata.db_filler import DbFiller
 from tests.api.utils.api_objects import ADCMTestApiWrapper, ExpectedBody
+from tests.api.utils.tools import not_set
 
 from tests.api.utils.types import get_fields
 from tests.api.utils.methods import Methods
@@ -70,9 +71,9 @@ def test_patch_body_positive(prepare_patch_body_data):
         # Set expected response fields
         test_data.response.body = ExpectedBody()
         for field in get_fields(test_data.request.endpoint.data_class):
-            test_data.response.body.fields.append(field.name)
+            test_data.response.body.fields[field.name] = not_set
             if expected_field_value := test_data.request.data.get(field.name):
-                test_data.response.body.fields_values[field.name] = expected_field_value
+                test_data.response.body.fields[field.name] = expected_field_value
         with allure.step(f'Assert - {test_data.description}'):
             adcm.exec_request(request=test_data.request, expected_response=test_data.response)
 

--- a/tests/api/test_body/test_post.py
+++ b/tests/api/test_body/test_post.py
@@ -17,7 +17,7 @@ from tests.api.testdata.db_filler import DbFiller
 from tests.api.utils.methods import Methods
 from tests.api.utils.types import get_fields
 
-from tests.api.utils.api_objects import ADCMTestApiWrapper
+from tests.api.utils.api_objects import ADCMTestApiWrapper, ExpectedBody
 
 pytestmark = [
     allure.suite("POST"),
@@ -66,6 +66,12 @@ def test_post_body_positive(prepare_post_body_data):
     """
     adcm, test_data_list = prepare_post_body_data
     for test_data in test_data_list:
+        # Set expected response fields values
+        test_data.response.body = ExpectedBody()
+        for field in get_fields(test_data.request.endpoint.data_class):
+            test_data.response.body.fields.append(field.name)
+            if (expected_field_value := test_data.request.data.get(field.name)) and field.postable:
+                test_data.response.body.fields_values[field.name] = expected_field_value
         with allure.step(f'Assert - {test_data.description}'):
             adcm.exec_request(request=test_data.request, expected_response=test_data.response)
 

--- a/tests/api/test_body/test_post.py
+++ b/tests/api/test_body/test_post.py
@@ -15,6 +15,7 @@ from tests.api.testdata.generators import (
 from tests.api.testdata.db_filler import DbFiller
 
 from tests.api.utils.methods import Methods
+from tests.api.utils.tools import not_set
 from tests.api.utils.types import get_fields
 
 from tests.api.utils.api_objects import ADCMTestApiWrapper, ExpectedBody
@@ -69,9 +70,9 @@ def test_post_body_positive(prepare_post_body_data):
         # Set expected response fields values
         test_data.response.body = ExpectedBody()
         for field in get_fields(test_data.request.endpoint.data_class):
-            test_data.response.body.fields.append(field.name)
+            test_data.response.body.fields[field.name] = not_set
             if (expected_field_value := test_data.request.data.get(field.name)) and field.postable:
-                test_data.response.body.fields_values[field.name] = expected_field_value
+                test_data.response.body.fields[field.name] = expected_field_value
         with allure.step(f'Assert - {test_data.description}'):
             adcm.exec_request(request=test_data.request, expected_response=test_data.response)
 

--- a/tests/api/test_body/test_put.py
+++ b/tests/api/test_body/test_put.py
@@ -14,6 +14,7 @@ from tests.api.testdata.generators import (
 )
 from tests.api.testdata.db_filler import DbFiller
 from tests.api.utils.api_objects import ADCMTestApiWrapper, ExpectedBody
+from tests.api.utils.tools import not_set
 
 from tests.api.utils.types import get_fields
 from tests.api.utils.methods import Methods
@@ -79,9 +80,9 @@ def test_put_body_positive(prepare_put_body_data):
         # Set expected response fields values
         test_data.response.body = ExpectedBody()
         for field in get_fields(test_data.request.endpoint.data_class):
-            test_data.response.body.fields.append(field.name)
+            test_data.response.body.fields[field.name] = not_set
             if expected_field_value := test_data.request.data.get(field.name):
-                test_data.response.body.fields_values[field.name] = expected_field_value
+                test_data.response.body.fields[field.name] = expected_field_value
         with allure.step(f'Assert - {test_data.description}'):
             adcm.exec_request(request=test_data.request, expected_response=test_data.response)
 

--- a/tests/api/test_body/test_put.py
+++ b/tests/api/test_body/test_put.py
@@ -13,7 +13,7 @@ from tests.api.testdata.generators import (
     TestDataWithPreparedBody,
 )
 from tests.api.testdata.db_filler import DbFiller
-from tests.api.utils.api_objects import ADCMTestApiWrapper
+from tests.api.utils.api_objects import ADCMTestApiWrapper, ExpectedBody
 
 from tests.api.utils.types import get_fields
 from tests.api.utils.methods import Methods
@@ -76,6 +76,12 @@ def test_put_body_positive(prepare_put_body_data):
     """
     adcm, test_data_list = prepare_put_body_data
     for test_data in test_data_list:
+        # Set expected response fields values
+        test_data.response.body = ExpectedBody()
+        for field in get_fields(test_data.request.endpoint.data_class):
+            test_data.response.body.fields.append(field.name)
+            if expected_field_value := test_data.request.data.get(field.name):
+                test_data.response.body.fields_values[field.name] = expected_field_value
         with allure.step(f'Assert - {test_data.description}'):
             adcm.exec_request(request=test_data.request, expected_response=test_data.response)
 

--- a/tests/api/testdata/generators.py
+++ b/tests/api/testdata/generators.py
@@ -10,7 +10,7 @@ import attr
 import pytest
 from _pytest.mark.structures import ParameterSet
 
-from tests.api.utils.api_objects import Request, ExpectedResponse
+from tests.api.utils.api_objects import Request, ExpectedResponse, ExpectedBody
 from tests.api.utils.endpoints import Endpoints
 from tests.api.utils.methods import Methods
 from tests.api.utils.tools import fill_lists_by_longest
@@ -498,7 +498,8 @@ def _prepare_test_data_with_one_by_one_fields(
         request_data = {}
         if not param_value.error_messages:
             continue
-        body = {param_name: param_value.get_error_data()}
+        body = ExpectedBody()
+        body.fields_values = {param_name: param_value.get_error_data()}
         request_data[param_name] = param_value
         request = Request(method=method, endpoint=endpoint)
         response = ExpectedResponse(status_code=status_code, body=body)

--- a/tests/api/utils/api_objects.py
+++ b/tests/api/utils/api_objects.py
@@ -1,35 +1,38 @@
 """Module contains api objects for executing and checking requests"""
+from dataclasses import field, dataclass
 from typing import Optional
 from urllib.parse import urlencode
 
 import allure
-import attr
 from adcm_client.wrappers.api import ADCMApiWrapper
 
 from .endpoints import Endpoints
 from .methods import Methods
 from .tools import attach_request_log
-from ..steps.asserts import status_code_should_be, body_should_be
+from ..steps.asserts import status_code_should_be, body_should_be, ExpectedBody
 
 
-@attr.dataclass
+@dataclass
 class Request:  # pylint: disable=too-few-public-methods
     """Request for a specific endpoint"""
 
     method: Methods
     endpoint: Endpoints
     object_id: Optional[int] = None
-    url_params: dict = {}
-    headers: dict = {}
-    data: dict = {}
+    url_params: dict = field(default_factory=dict)
+    headers: dict = field(default_factory=dict)
+    data: dict = field(default_factory=dict)
 
 
-@attr.dataclass
+@dataclass
 class ExpectedResponse:  # pylint: disable=too-few-public-methods
-    """Response to be expected. Checking the status code and body if present"""
+    """
+    Response to be expected.
+    Checking the status code and body or some fields values if present
+    """
 
     status_code: int
-    body: Optional[dict] = None
+    body: Optional[ExpectedBody] = None
 
 
 class ADCMTestApiWrapper:

--- a/tests/api/utils/endpoints.py
+++ b/tests/api/utils/endpoints.py
@@ -14,7 +14,7 @@ from .data_classes import (
     ClusterFields,
     ServiceFields,
     ComponentFields,
-    ProviderFields
+    ProviderFields, ObjectConfigFields, ConfigLogFields
 )
 from .methods import Methods
 from .types import get_fields
@@ -137,13 +137,31 @@ class Endpoints(Enum):
         technical=True
     )
 
+    ObjectConfig = Endpoint(
+        path="object-config",
+        methods=[
+            Methods.GET, Methods.LIST
+        ],
+        data_class=ObjectConfigFields,
+        spec_link="https://spec.adsw.io/adcm_core/objects.html#object-config",
+    )
+
+    ConfigLog = Endpoint(
+        path="config-log",
+        methods=[
+            Methods.GET, Methods.LIST, Methods.POST
+        ],
+        data_class=ConfigLogFields,
+        spec_link="https://spec.adsw.io/adcm_core/objects.html#object-config",
+    )
+
     ConfigGroup = Endpoint(
         path="config-group",
         methods=[
             Methods.GET, Methods.LIST, Methods.POST, Methods.PUT, Methods.PATCH, Methods.DELETE
         ],
         data_class=ConfigGroupFields,
-        spec_link="https://spec.adsw.io/adcm_core/objects.html#group",
+        spec_link="https://spec.adsw.io/adcm_core/objects.html#config-group",
     )
 
     HostGroup = Endpoint(
@@ -152,5 +170,5 @@ class Endpoints(Enum):
             Methods.GET, Methods.LIST, Methods.POST, Methods.PUT, Methods.PATCH, Methods.DELETE
         ],
         data_class=HostGroupFields,
-        spec_link="https://spec.adsw.io/adcm_core/objects.html#group",
+        spec_link="https://spec.adsw.io/adcm_core/objects.html#host-group",
     )

--- a/tests/api/utils/fake_data.py
+++ b/tests/api/utils/fake_data.py
@@ -3,6 +3,7 @@ Dummy data generators
 """
 
 from random import randint, choice
+from genson import SchemaBuilder
 
 import allure
 from rstr.xeger import Xeger
@@ -124,9 +125,9 @@ def gen_object(prop=None):
     output = {}
     prop_key = "properties"
     if prop.get("properties", None) is None:
-        if prop["additionalProperties"] is True or prop["additionalProperties"] == {}:
+        if prop.get("additionalProperties") is True or prop.get("additionalProperties") == {}:
             return _gen_any_obj()
-        return {key: gen_string() for key in prop["additionalProperties"]}
+        return {key: gen_string() for key in prop.get("additionalProperties", {})}
 
     for k in prop[prop_key].keys():
         json_prop = prop[prop_key][k]
@@ -189,6 +190,15 @@ def generate_json_from_schema(json_schema):
     if not json_schema:
         return _gen_any_obj()
     return _get_generator(json_schema)
+
+
+def build_schema_by_json(json):
+    """
+    Build Json Schema by json value
+    """
+    sch_builder = SchemaBuilder()
+    sch_builder.add_object(json)
+    return sch_builder.to_schema()
 
 
 class JsonTypeError(Exception):

--- a/tests/api/utils/tools.py
+++ b/tests/api/utils/tools.py
@@ -11,6 +11,13 @@ import allure
 from requests_toolbelt.utils import dump
 
 
+class NotSet:
+    pass
+
+
+not_set = NotSet()
+
+
 def wait_for_url(url: str, timeout=120) -> None:
     """Wait until url becomes available"""
     for _ in range(timeout):


### PR DESCRIPTION
 - rethinking `relates_on`: now relates logic should be described for each `dataclass` field with relation
 - now we check response body fields (assert that field is in body, values for created and changed fields)
 - add new endpoints