### PR TITLE
ADCM-2050 Intger overflow on DB save

### DIFF
--- a/python/adcm/settings.py
+++ b/python/adcm/settings.py
@@ -129,6 +129,7 @@ REST_FRAMEWORK = {
         'django_filters.rest_framework.DjangoFilterBackend',
         'rest_framework.filters.OrderingFilter',
     ],
+    'EXCEPTION_HANDLER': 'cm.errors.custom_drf_exception_handler',
 }
 
 # Database


### PR DESCRIPTION
We have a HTTP 500 in case of integer overflow on SQLite.
This commit adds top level handler of OverFlow exception and
make an HTTP 400 response in such cases.