### PR TITLE
SPEC: TEST: add config_id to group-config

### DIFF
--- a/pytest.sh
+++ b/pytest.sh
@@ -18,7 +18,8 @@ pip3 install -r requirements-test.txt
 find . -name "*.pyc" -type f -delete
 find . -name "__pycache__" -type d -delete
 { # try
-    pytest tests/api tests/functional tests/ui_tests -s -v -n auto \
+    # pytest tests/api tests/functional tests/ui_tests -s -v -n auto \
+    pytest tests/api/test_body/test_patch.py -s -v -n auto \
     --showlocals --alluredir ./allure-results/ --durations=20 -p allure_pytest \
     --reruns 2 --remote-executor-host "$SELENOID_HOST" --timeout=1080 "$@" &&
     chmod -R o+xw allure-results

--- a/pytest.sh
+++ b/pytest.sh
@@ -18,8 +18,7 @@ pip3 install -r requirements-test.txt
 find . -name "*.pyc" -type f -delete
 find . -name "__pycache__" -type d -delete
 { # try
-    # pytest tests/api tests/functional tests/ui_tests -s -v -n auto \
-    pytest tests/api/test_body/test_patch.py -s -v -n auto \
+    pytest tests/api tests/functional tests/ui_tests -s -v -n auto \
     --showlocals --alluredir ./allure-results/ --durations=20 -p allure_pytest \
     --reruns 2 --remote-executor-host "$SELENOID_HOST" --timeout=1080 "$@" &&
     chmod -R o+xw allure-results

--- a/spec/objects.rst
+++ b/spec/objects.rst
@@ -89,6 +89,7 @@ description         text    null    False    False            True              
 hosts               M2M     null    False    False            False              False              M2M link to Host objects.
 host_candidate      link    null    False    False            False              False              Reference to list host candidate for adding to a group
 config              FK      null    False    False            False              False              FK field on ObjectConfig object
+config_id           integer null    False    False            False              False              Additional information about config. Read Only.
 url                 link    null    False    False            False              False              Reference to this object
 =================== ======= ======= ======== ================ ================== ================== ===========
 

--- a/tests/api/utils/data_classes.py
+++ b/tests/api/utils/data_classes.py
@@ -112,7 +112,7 @@ class GroupConfigFields(BaseClass):
         f_type=ForeignKey(fk_link=ObjectConfigFields),
         default_value="auto",
     )
-    config_id = Field(name='config_id', f_type=PositiveInt(), postable=False, changeable=False, default_value=None)
+    config_id = Field(name='config_id', f_type=PositiveInt(), default_value="auto")
     host_candidate = Field(
         # Link to host candidates url for this object. Auto-filled when group-config object creates
         # Candidates list depends on ADCM object for which group-config was created.

--- a/tests/api/utils/data_classes.py
+++ b/tests/api/utils/data_classes.py
@@ -112,6 +112,7 @@ class GroupConfigFields(BaseClass):
         f_type=ForeignKey(fk_link=ObjectConfigFields),
         default_value="auto",
     )
+    config_id = Field(name='config_id', f_type=PositiveInt(), postable=False, changeable=False, default_value=None)
     host_candidate = Field(
         # Link to host candidates url for this object. Auto-filled when group-config object creates
         # Candidates list depends on ADCM object for which group-config was created.


### PR DESCRIPTION
This commit adds config_id field to group-config endpoint.
config_id had been added to backend implementation in some
previous commits.