### PR TITLE
ADCM-2053 config on group-config should be RO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .cache
 .coverage
 .idea/
+.venv
 .version
 .vscode
 /allure-results/

--- a/python/api/group_config/serializers.py
+++ b/python/api/group_config/serializers.py
@@ -102,6 +102,7 @@ class GroupConfigSerializer(FlexFieldsSerializerMixin, serializers.ModelSerializ
         lookup_field='config_id',
         lookup_url_kwarg='pk',
         source='*',
+        read_only=True,
     )
     host_candidate = serializers.HyperlinkedRelatedField(
         view_name='group-config-host-candidate-list',

--- a/python/cm/models.py
+++ b/python/cm/models.py
@@ -649,7 +649,7 @@ class GroupConfig(ADCMModel):
     description = models.TextField(blank=True)
     hosts = models.ManyToManyField(Host, blank=True, related_name='group_config')
     config = models.OneToOneField(
-        ObjectConfig, on_delete=models.CASCADE, null=True, related_name='group_config'
+        ObjectConfig, on_delete=models.CASCADE, null=False, related_name='group_config'
     )
 
     __error_code__ = 'GROUP_CONFIG_NOT_FOUND'


### PR DESCRIPTION
This commit changes rules around config attribute on group-config. 
According to spec it should be readonly and non nullable.