### PR TITLE
ADCM-2159 Reverse order of object in link on job

### DIFF
--- a/web/src/app/helpers/objects-helper.ts
+++ b/web/src/app/helpers/objects-helper.ts
@@ -20,11 +20,11 @@ export class ObjectsHelper {
 
   static sortObjects(objects: JobObject[]): JobObject[] {
     return [
-      ObjectsHelper.getObject(objects, 'host'),
-      ObjectsHelper.getObject(objects, 'provider'),
-      ObjectsHelper.getObject(objects, 'component'),
-      ObjectsHelper.getObject(objects, 'service'),
       ObjectsHelper.getObject(objects, 'cluster'),
+      ObjectsHelper.getObject(objects, 'service'),
+      ObjectsHelper.getObject(objects, 'component'),
+      ObjectsHelper.getObject(objects, 'provider'),
+      ObjectsHelper.getObject(objects, 'host'),
     ].filter(Boolean);
   }
 


### PR DESCRIPTION
The commit makes order of object more natural. It starts from
cluster and ends on host.