### PR TITLE
Freeze selenium ver

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,7 +14,7 @@ pytest-timeout
 pyyaml
 requests
 requests-toolbelt
-selenium
+selenium~=3.141.0
 multipledispatch
 rstr
 genson


### PR DESCRIPTION
We need to freeze the Selenium version to 3 because the new release is failing some of our tests