### PR TITLE
ADCM-1586 Test on `secrettext` config field type

### DIFF
--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -712,7 +712,7 @@ def provider(request: SubRequest, sdk_client_fs: ADCMClient) -> Provider:
 class TestConfigFieldTypes:
     """Test different types of fields"""
 
-    # pylint: disable-next=too-many-locals
+    # pylint: disable=too-many-locals
     @pytest.mark.parametrize('cluster', ["secret_text"], indirect=True)
     @pytest.mark.parametrize('provider', ["secret_text"], indirect=True)
     def test_secret_text_field(self, cluster: Cluster, provider: Provider):

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -15,6 +15,8 @@
 """Tests for config"""
 
 import os
+from typing import Tuple
+
 import allure
 import yaml
 import pytest
@@ -27,6 +29,7 @@ from adcm_client.base import ActionHasIssues
 from adcm_client.objects import ADCMClient, Cluster, Service, Provider, Host
 from adcm_pytest_plugin.utils import fixture_parametrized_by_data_subdirs, get_data_dir
 
+from tests.functional.plugin_utils import AnyADCMObject
 from tests.library.errorcodes import CONFIG_KEY_ERROR, ADCMError, CONFIG_NOT_FOUND
 
 
@@ -682,9 +685,6 @@ def test_required_without_default_sent_null_value(r_wod_nv):
     assert_config_type(*r_wod_nv, True, False, 'null_value')
 
 
-# !===== Negative scenarious =====!
-
-
 @pytest.fixture()
 def cluster(request: SubRequest, sdk_client_fs: ADCMClient) -> Cluster:
     """Upload cluster bundle, create cluster, add service"""
@@ -701,8 +701,75 @@ def provider(request: SubRequest, sdk_client_fs: ADCMClient) -> Provider:
     bundle_subdir = request.param if hasattr(request, 'param') else "simple_config"
     bundle = sdk_client_fs.upload_from_fs(os.path.join(get_data_dir(__file__), bundle_subdir, "provider"))
     provider = bundle.provider_create(name='test_provider')
-    provider.host_create(fqdn='test_service')
+    provider.host_create(fqdn='test-host')
     return provider
+
+
+# !===== Secret text config field type =====!
+
+
+# pylint: disable-next=too-few-public-methods
+class TestConfigFieldTypes:
+    """Test different types of fields"""
+
+    # pylint: disable-next=too-many-locals
+    @pytest.mark.parametrize('cluster', ["secret_text"], indirect=True)
+    @pytest.mark.parametrize('provider', ["secret_text"], indirect=True)
+    def test_secret_text_field(self, cluster: Cluster, provider: Provider):
+        """Test "secrettext" config field type"""
+        value_to_set = "verysimple\nI'am"
+        default_value = "very\nsecret\ntext"
+        fields = (
+            'secret_required_default',
+            'secret_not_required_default',
+            'secret_not_required_no_default',
+            'secret_required_no_default',
+        )
+        required_default, not_required_default, not_required_no_default, required_no_default = fields
+        required_diff = {required_no_default: value_to_set}
+        changed_diff = {field: value_to_set for field in fields if field != required_no_default}
+        default_diff = {
+            not_required_no_default: None,
+            required_default: default_value,
+            not_required_default: default_value,
+        }
+
+        component = (service := cluster.service()).component()
+        host = provider.host()
+        cluster.host_add(host)
+        cluster.hostcomponent_set((host, component))
+        objects_to_change = (cluster, service, component, provider, host)
+
+        # to make actions available
+        with allure.step(f'Set required fields that has no default to {value_to_set}'):
+            for adcm_object in objects_to_change:
+                adcm_object.config_set_diff(required_diff)
+        with allure.step(f'Set other fields to {value_to_set} and check that config changed correctly'):
+            self._change_config_and_check_changed_by_action(
+                objects_to_change, changed_diff, 'check_default', 'check_changed'
+            )
+        with allure.step('Set default values for fields and check that config changed correctly'):
+            self._change_config_and_check_changed_by_action(
+                objects_to_change, default_diff, 'check_changed', 'check_default'
+            )
+
+    # pylint: disable-next=no-self-use
+    def _change_config_and_check_changed_by_action(
+        self, objects_to_change: Tuple[AnyADCMObject], config_to_set: dict, action_before: str, action_after: str
+    ):
+        """
+        Loop over objects_to_change:
+        1. Run `action_before` to ensure state before config change is correct
+        2. Change config
+        3. Run `action_after` to ensure config changed correctly
+        """
+        for adcm_object in objects_to_change:
+            _run_action_and_assert_status(adcm_object, action_before)
+            adcm_object.config_set_diff(config_to_set)
+            _run_action_and_assert_status(adcm_object, action_after)
+
+
+# !===== Negative scenarios =====!
 
 
 @pytest.mark.parametrize("cluster", ["no_config"], indirect=True)
@@ -729,3 +796,15 @@ def _expect_correct_fail_on_config(cluster: Cluster, provider: Provider, config:
                 error.equal(e)
             else:
                 raise AssertionError("Config set should've failed")
+
+
+@allure.step("Run action '{action_name}' on {adcm_object} and expect status '{expected_status}'")
+def _run_action_and_assert_status(adcm_object: AnyADCMObject, action_name: str, expected_status: str = 'success'):
+    """
+    Run action on any ADCM object and assert status
+    """
+    assert (
+        actual_status := adcm_object.action(name=action_name).run().wait()
+    ) == expected_status, (
+        f"Actions '{action_name}' is expected to finish with status '{expected_status}', not '{actual_status}'"
+    )

--- a/tests/functional/test_config_after_upgrade.py
+++ b/tests/functional/test_config_after_upgrade.py
@@ -147,6 +147,7 @@ def _update_config_and_attr_for_changed_group_customisation_test(
         attr["custom_group_keys"]["option"] = False
         attr["custom_group_keys"]["group"] = {"port": False, "transport_port": False}
         attr["custom_group_keys"]["map"] = False
+        attr["custom_group_keys"]["secrettext"] = True
 
     return config, attr
 

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_configs_with_changed_types/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_configs_with_changed_types/config.yaml
@@ -97,6 +97,11 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: service
   name: test_service
@@ -177,6 +182,7 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
 
   components:
     test_component:
@@ -256,3 +262,4 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_configs_with_new_default_value/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_configs_with_new_default_value/config.yaml
@@ -95,6 +95,11 @@
         age: '25'
         name: Jane
         sex: f
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "new\nidentity"
 
 - type: service
   name: test_service
@@ -173,6 +178,7 @@
         age: '25'
         name: Jane
         sex: f
+    - *secrettext
 
   components:
     test_component:
@@ -250,3 +256,4 @@
             age: '25'
             name: Jane
             sex: f
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_configs_with_new_fields/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_configs_with_new_fields/config.yaml
@@ -158,7 +158,11 @@
       default:
         time: '12'
         range: 'super long'
-
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 - type: service
   name: test_service
   version: 1.6
@@ -299,6 +303,7 @@
       default:
         time: '12'
         range: 'super long'
+    - *secrettext
 
   components:
     test_component:
@@ -439,3 +444,4 @@
           default:
             time: '12'
             range: 'super long'
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_changed_group_customisation/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_changed_group_customisation/config.yaml
@@ -103,6 +103,12 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
+      group_customization: true
 
 - type: service
   name: test_service
@@ -189,6 +195,7 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
 
   components:
     test_component:
@@ -274,3 +281,4 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_changed_types/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_changed_types/config.yaml
@@ -98,6 +98,11 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: text
+      required: false
+      default: "sec\nret\ntext"
 
 - type: service
   name: test_service
@@ -179,6 +184,7 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
 
   components:
     test_component:
@@ -259,3 +265,4 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_new_default_value/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_new_default_value/config.yaml
@@ -96,6 +96,11 @@
         age: '25'
         name: Jane
         sex: f
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "new\nidentity"
 
 - type: service
   name: test_service
@@ -175,6 +180,7 @@
         age: '25'
         name: Jane
         sex: f
+    - *secrettext
 
   components:
     test_component:
@@ -253,3 +259,4 @@
             age: '25'
             name: Jane
             sex: f
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_new_fields/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_for_upgrade_with_group_configs_with_new_fields/config.yaml
@@ -159,6 +159,12 @@
       default:
         time: '12'
         range: 'super long'
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
+
 
 - type: service
   name: test_service
@@ -301,6 +307,7 @@
       default:
         time: '12'
         range: 'super long'
+    - *secrettext
 
   components:
     test_component:
@@ -442,3 +449,4 @@
           default:
             time: '12'
             range: 'super long'
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_with_configs/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_with_configs/config.yaml
@@ -89,6 +89,11 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: service
   name: test_service
@@ -169,6 +174,7 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
 
   components:
     test_component:
@@ -248,3 +254,4 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/cluster_with_group_configs/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/cluster_with_group_configs/config.yaml
@@ -90,6 +90,11 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: service
   name: test_service
@@ -171,6 +176,7 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
 
   components:
     test_component:
@@ -251,3 +257,4 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_configs_with_changed_types/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_configs_with_changed_types/config.yaml
@@ -97,6 +97,10 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: text
+      required: false
+      default: "sec\nret\ntext"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_configs_with_new_default_value/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_configs_with_new_default_value/config.yaml
@@ -95,6 +95,10 @@
         age: '25'
         name: Jane
         sex: f
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "new\nidentity"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_configs_with_new_fields/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_configs_with_new_fields/config.yaml
@@ -158,6 +158,10 @@
       default:
         time: '12'
         range: 'super long'
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_changed_group_customisation/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_changed_group_customisation/config.yaml
@@ -103,6 +103,11 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
+      group_customization: true
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_changed_types/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_changed_types/config.yaml
@@ -98,6 +98,10 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: text
+      required: false
+      default: "sec\nret\ntext"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_new_default_value/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_new_default_value/config.yaml
@@ -96,6 +96,10 @@
         age: '25'
         name: Jane
         sex: f
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "new\nidentity"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_new_fields/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_for_upgrade_with_group_configs_with_new_fields/config.yaml
@@ -159,6 +159,10 @@
       default:
         time: '12'
         range: 'super long'
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_with_configs/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_with_configs/config.yaml
@@ -89,6 +89,10 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_after_upgrade_data/provider_with_group_configs/config.yaml
+++ b/tests/functional/test_config_after_upgrade_data/provider_with_group_configs/config.yaml
@@ -90,6 +90,10 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "sec\nret\ntext"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_data/secret_text/cluster/actions.yaml
+++ b/tests/functional/test_config_data/secret_text/cluster/actions.yaml
@@ -1,0 +1,177 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- hosts: all
+  connection: local
+  gather_facts: no
+  vars:
+    default_pass: "very\nsecret\ntext"
+    changed_pass: "verysimple\nI'am"
+
+  tasks:
+    # cluster
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ default_pass }}\nbut found: {{ cluster.config.secret_required_default }}"
+      when: "cluster.config.secret_required_default != default_pass"
+      tags:
+        - cluster_before
+
+    # we don't check required without default because we can't launch action without setting it to something
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ default_pass }}\nbut found: {{ cluster.config.secret_not_required_default }}"
+      when: "cluster.config.secret_not_required_default != default_pass"
+      tags:
+        - cluster_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected empty value in secret_not_required_no_default\nbut found: {{ cluster.config.secret_not_required_no_default }}"
+      when: "cluster.config.secret_not_required_no_default | bool"
+      tags:
+        - cluster_before
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ changed_pass }}\nbut found: {{ cluster.config.secret_required_default }}"
+      when: "cluster.config.secret_required_default != changed_pass"
+      tags:
+        - cluster_after
+
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_no_default {{ changed_pass }}\nbut found: {{ cluster.config.secret_required_no_default }}"
+      when: "cluster.config.secret_required_no_default != changed_pass"
+      tags:
+        - cluster_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ changed_pass }}\nbut found: {{ cluster.config.secret_not_required_default }}"
+      when: "cluster.config.secret_not_required_default != changed_pass"
+      tags:
+        - cluster_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_no_default: {{ changed_pass }}\nbut found: {{ cluster.config.secret_not_required_no_default }}"
+      when: "cluster.config.secret_not_required_no_default != changed_pass"
+      tags:
+        - cluster_after
+
+    # service
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ default_pass }}\nbut found: {{ services.test_service.config.secret_required_default }}"
+      when: "services.test_service.config.secret_required_default != default_pass"
+      tags:
+        - service_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ default_pass }}\nbut found: {{ services.test_service.config.secret_not_required_default }}"
+      when: "services.test_service.config.secret_not_required_default != default_pass"
+      tags:
+        - service_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected empty value in secret_not_required_no_default\nbut found: {{ services.test_service.config.secret_not_required_no_default }}"
+      when: "services.test_service.config.secret_not_required_no_default | bool"
+      tags:
+        - service_before
+
+    - name: check_after_value
+      fail:
+        msg: "Expected in secret_required_default: {{ changed_pass }}\nbut found: {{ services.test_service.config.secret_required_default }}"
+      when: "services.test_service.config.secret_required_default != changed_pass"
+      tags:
+        - service_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_no_default: {{ changed_pass }}\nbut found: {{ services.test_service.config.secret_required_no_default }}"
+      when: "services.test_service.config.secret_required_no_default != changed_pass"
+      tags:
+        - service_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ changed_pass }}\nbut found: {{ services.test_service.config.secret_not_required_default }}"
+      when: "services.test_service.config.secret_not_required_default != changed_pass"
+      tags:
+        - service_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_no_default: {{ changed_pass }}\nbut found: {{ services.test_service.config.secret_not_required_no_default }}"
+      when: "services.test_service.config.secret_not_required_no_default != changed_pass"
+      tags:
+        - service_after
+
+    # component
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ default_pass }}\nbut found: {{ services.test_service.test_component.config.secret_required_default }}"
+      when: "services.test_service.test_component.config.secret_required_default != default_pass"
+      tags:
+        - component_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ default_pass }}\nbut found: {{ services.test_service.test_component.config.secret_not_required_default }}"
+      when: "services.test_service.test_component.config.secret_not_required_default != default_pass"
+      tags:
+        - component_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected empty value in secret_not_required_no_default\nbut found: {{ services.test_service.test_component.config.secret_not_required_no_default }}"
+      when: "services.test_service.test_component.config.secret_not_required_no_default | bool"
+      tags:
+        - component_before
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ changed_pass }}\nbut found: {{ services.test_service.test_component.config.secret_required_default }}"
+      when: "services.test_service.test_component.config.secret_required_default != changed_pass"
+      tags:
+        - component_after
+
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_no_default: {{ changed_pass }}\nbut found: {{ services.test_service.test_component.config.secret_required_no_default }}"
+      when: "services.test_service.test_component.config.secret_required_no_default != changed_pass"
+      tags:
+        - component_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ changed_pass }}\nbut found: {{ services.test_service.test_component.config.secret_not_required_default }}"
+      when: "services.test_service.test_component.config.secret_not_required_default != changed_pass"
+      tags:
+        - component_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_no_default: {{ changed_pass }}\nbut found: {{ services.test_service.test_component.config.secret_not_required_no_default }}"
+      when: "services.test_service.test_component.config.secret_not_required_no_default != changed_pass"
+      tags:
+        - component_after
+

--- a/tests/functional/test_config_data/secret_text/cluster/config.yaml
+++ b/tests/functional/test_config_data/secret_text/cluster/config.yaml
@@ -1,0 +1,81 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- type: cluster
+  version: 7.4.0
+  name: test_cluster
+
+  config: &config
+    secret_required_default:
+      type: secrettext
+      required: true
+      default: "very\nsecret\ntext"
+
+    secret_required_no_default:
+      type: secrettext
+      required: true
+
+    secret_not_required_default:
+      type: secrettext
+      required: false
+      default: "very\nsecret\ntext"
+
+    secret_not_required_no_default:
+      type: secrettext
+      required: false
+
+  actions:
+    check_default: &check_job
+      type: job
+      script_type: ansible
+      script: ./actions.yaml
+      states:
+        available: any
+      params:
+        ansible_tags: cluster_before
+
+    check_changed:
+      <<: *check_job
+      params:
+        ansible_tags: cluster_after
+
+- type: service
+  version: 4.2.0
+  name: test_service
+
+  config: *config
+
+  actions:
+    check_default:
+      <<: *check_job
+      params:
+        ansible_tags: service_before
+
+    check_changed:
+      <<: *check_job
+      params:
+        ansible_tags: service_after
+
+  components:
+    test_component:
+      config: *config
+
+      actions:
+        check_default:
+          <<: *check_job
+          params:
+            ansible_tags: component_before
+
+        check_changed:
+          <<: *check_job
+          params:
+            ansible_tags: component_after

--- a/tests/functional/test_config_data/secret_text/provider/actions.yaml
+++ b/tests/functional/test_config_data/secret_text/provider/actions.yaml
@@ -1,0 +1,121 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- hosts: all
+  connection: local
+  gather_facts: no
+  vars:
+    default_pass: "very\nsecret\ntext"
+    changed_pass: "verysimple\nI'am"
+
+  tasks:
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ default_pass }}\nbut found: {{ provider.config.secret_required_default }}"
+      when: "provider.config.secret_required_default != default_pass"
+      tags:
+        - provider_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ default_pass }}\nbut found: {{ provider.config.secret_not_required_default }}"
+      when: "provider.config.secret_not_required_default != default_pass"
+      tags:
+        - provider_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected empty value in secret_not_required_no_default\nbut found: {{ provider.config.secret_not_required_no_default }}"
+      when: "provider.config.secret_not_required_no_default | bool"
+      tags:
+        - provider_before
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ changed_pass }}\nbut found: {{ provider.config.secret_required_default }}"
+      when: "provider.config.secret_required_default != changed_pass"
+      tags:
+        - provider_after
+
+
+    - name: check_after_value
+      fail:
+        msg: "Expected in secret_required_no_default: {{ changed_pass }}\nbut found: {{ provider.config.secret_required_no_default }}"
+      when: "provider.config.secret_required_no_default != changed_pass"
+      tags:
+        - provider_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ changed_pass }}\nbut found: {{ provider.config.secret_not_required_default }}"
+      when: "provider.config.secret_not_required_default != changed_pass"
+      tags:
+        - provider_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_no_default: {{ changed_pass }}\nbut found: {{ provider.config.secret_not_required_no_default }}"
+      when: "provider.config.secret_not_required_no_default != changed_pass"
+      tags:
+        - provider_after
+
+    # host
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ default_pass }}\nbut found: {{ secret_required_default }}"
+      when: "secret_required_default != default_pass"
+      tags:
+        - host_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ default_pass }}\nbut found: {{ secret_not_required_default }}"
+      when: "secret_not_required_default != default_pass"
+      tags:
+        - host_before
+
+    - name: check_before_value
+      fail:
+        msg: "Expected empty value in secret_not_required_no_default\nbut found: {{ secret_not_required_no_default }}"
+      when: "secret_not_required_no_default | bool"
+      tags:
+        - host_before
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_default: {{ changed_pass }}\nbut found: {{ secret_required_default }}"
+      when: "secret_required_default != changed_pass"
+      tags:
+        - host_after
+
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_required_no_default: {{ changed_pass }}\nbut found: {{ secret_required_no_default }}"
+      when: "secret_required_no_default != changed_pass"
+      tags:
+        - host_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_default: {{ changed_pass }}, but found: {{ secret_not_required_default }}"
+      when: "secret_not_required_default != changed_pass"
+      tags:
+        - host_after
+
+    - name: check_after_value
+      fail:
+        msg: "Expected value in secret_not_required_no_default: {{ changed_pass }}, but found: {{ secret_not_required_no_default }}"
+      when: "secret_not_required_no_default != changed_pass"
+      tags:
+        - host_after

--- a/tests/functional/test_config_data/secret_text/provider/config.yaml
+++ b/tests/functional/test_config_data/secret_text/provider/config.yaml
@@ -1,0 +1,65 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- type: provider
+  version: 12
+  name: test_provider
+  config: &config
+    secret_required_default:
+      type: secrettext
+      required: true
+      default: "very\nsecret\ntext"
+
+    secret_required_no_default:
+      type: secrettext
+      required: true
+
+    secret_not_required_default:
+      type: secrettext
+      required: false
+      default: "very\nsecret\ntext"
+
+    secret_not_required_no_default:
+      type: secrettext
+      required: false
+
+  actions:
+    check_default: &check_job
+      type: job
+      script_type: ansible
+      script: ./actions.yaml
+      states:
+        available: any
+      params:
+        ansible_tags: provider_before
+
+    check_changed:
+      <<: *check_job
+      params:
+        ansible_tags: provider_after
+
+- type: host
+  version: 4.3
+  name: hehehost
+
+  config: *config
+
+  actions:
+    check_default:
+      <<: *check_job
+      params:
+        ansible_tags: host_before
+
+    check_changed:
+      <<: *check_job
+      params:
+        ansible_tags: host_after

--- a/tests/functional/test_config_groups.py
+++ b/tests/functional/test_config_groups.py
@@ -378,6 +378,7 @@ class TestChangeGroupsConfig:
         "map": {"age": "20", "name": "Chloe", "sex": "f"},
         "password": "123",
         "file": "file content test",
+        "secrettext": "awesome\npa$$",
     }
 
     GROUP_KEYS_TO_CHANGE = {
@@ -393,6 +394,7 @@ class TestChangeGroupsConfig:
         "group": {"port": True, "transport_port": True},
         "structure": True,
         "map": True,
+        "secrettext": True,
     }
 
     CUSTOM_GROUP_KEYS_TO_CHANGE = {
@@ -408,6 +410,7 @@ class TestChangeGroupsConfig:
         "group": {"port": False, "transport_port": False},
         "structure": False,
         "map": False,
+        "secrettext": False,
     }
 
     CLUSTER_HOSTS_VARIANTS = [
@@ -448,6 +451,7 @@ class TestChangeGroupsConfig:
             ), f'Value is "{values_after[item]}", but should be {expected_values[item]}'
         if values_before:
             assert values_after["password"] != values_before["password"], "Password has not changed"
+            assert values_after["secrettext"] != values_before["secrettext"], "Secrettext has not changed"
         if values_after["file"]:
             assert values_after["file"] == expected_values["file"], "File has not changed"
 
@@ -456,6 +460,8 @@ class TestChangeGroupsConfig:
         config_group = cluster_group.config()
         if "password" in config_group:
             config_group["password"] = "password"
+        if "secrettext" in config_group:
+            config_group["secrettext"] = "secret\npass\nword"
         if "file" in config_group:
             config_group["file"] = config_group["file"].replace("\n", "")
         return config_group

--- a/tests/functional/test_config_groups_data/cluster_with_config_group_custom/cluster/config.yaml
+++ b/tests/functional/test_config_groups_data/cluster_with_config_group_custom/cluster/config.yaml
@@ -108,6 +108,11 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      default: "secret\npass\nword"
 
 - name: test_service_1
   type: service
@@ -205,6 +210,8 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
+
   components:
     first:
       constraint: [1,+]
@@ -302,6 +309,8 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext
+
     second:
       constraint: [1,+]
 

--- a/tests/functional/test_config_groups_data/cluster_with_group_all_params/cluster/config.yaml
+++ b/tests/functional/test_config_groups_data/cluster_with_group_all_params/cluster/config.yaml
@@ -122,6 +122,12 @@
         age: '24'
         name: Joe
         sex: m
+    - &secrettext
+      name: secrettext
+      type: secrettext
+      required: false
+      group_customization: true
+      default: "secret\npass\nword"
 
 - name: test_service_1
   type: service
@@ -233,6 +239,8 @@
         age: '24'
         name: Joe
         sex: m
+    - *secrettext
+
   components:
     first:
       constraint: [1,+]
@@ -344,6 +352,8 @@
             age: '24'
             name: Joe
             sex: m
+        - *secrettext
+
     second:
       constraint: [1,+]
 

--- a/tests/functional/test_config_groups_data/provider_group_with_all_params/provider/config.yaml
+++ b/tests/functional/test_config_groups_data/provider_group_with_all_params/provider/config.yaml
@@ -120,6 +120,10 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "secret\npass\nword"
 
 - type: host
   name: host_from_provider

--- a/tests/functional/test_config_groups_data/provider_group_with_config_group_custom/provider/config.yaml
+++ b/tests/functional/test_config_groups_data/provider_group_with_config_group_custom/provider/config.yaml
@@ -106,6 +106,10 @@
         age: '24'
         name: Joe
         sex: m
+    - name: secrettext
+      type: secrettext
+      required: false
+      default: "secret\npass\nword"
 
 - type: host
   name: host_from_provider


### PR DESCRIPTION
Test on `secrettext` config field type and `secrettext` added to tests on config change after cluster/provider upgrade and to config group tests (where it's possible)