### PR TITLE
disable pylint use-implicit-booleaness-not-comparison

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -54,7 +54,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 
-disable=missing-docstring,invalid-name,no-self-use,abstract-method,unused-argument,no-else-return,duplicate-code,fixme,no-member,too-few-public-methods,wrong-import-order,useless-import-alias,consider-using-with
+disable=missing-docstring,invalid-name,no-self-use,abstract-method,unused-argument,no-else-return,duplicate-code,fixme,no-member,too-few-public-methods,wrong-import-order,useless-import-alias,consider-using-with,use-implicit-booleaness-not-comparison
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -33,7 +33,8 @@ min-similarity-lines=5
 
 [tool.pylint.message_control]
 disable=[
-    "fixme"
+    "fixme",
+    "use-implicit-booleaness-not-comparison"
 ]
 
 [tool.pylint.basic]


### PR DESCRIPTION
I believe, we don't need that:
[C1803(use-implicit-booleaness-not-comparison), assert_events] 'expected_list != []' can be simplified to 'expected_list' as an empty sequence is falsey