### PR TITLE
ADCM-2377 Speed up dev tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://ci.arenadata.io/artifactory/api/pypi/python-packages/simple
 adcm-client>=2021.7.21
-adcm_pytest_plugin~=4.10
+adcm-pytest-plugin~=4.14
 attr
 allure-pytest
 docker

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -11,16 +11,30 @@
 # limitations under the License.
 
 """ADCM API tests fixtures"""
-import os
 
 import allure
 import pytest
-from adcm_client.objects import ADCMClient, Cluster, Service
-from adcm_pytest_plugin.utils import get_or_add_service
 
 from tests.api.steps.asserts import BodyAssertionError
 from tests.api.steps.common import assume_step
 from tests.api.utils.api_objects import ADCMTestApiWrapper
+
+
+@allure.title("Additional ADCM init config")
+@pytest.fixture(
+    scope="session",
+    params=[
+        pytest.param({"fill_dummy_data": True}, id="adcm_with_dummy_data"),
+    ],
+)
+def additional_adcm_init_config(request) -> dict:
+    """
+    Add options for ADCM init.
+    Redefine this fixture in the actual project to alter additional options of ADCM initialisation.
+    Ex. If this fixture will return {"fill_dummy_data": True}
+    then on the init stage dummy objects will be added to ADCM image
+    """
+    return request.param
 
 
 def pytest_addoption(parser):
@@ -35,41 +49,11 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture()
-def prepare_basic_adcm_data(sdk_client_fs: ADCMClient) -> ADCMClient:
-    """
-    Prepare ADCM with dummy provider and cluster bundle.
-    Add 3 providers, 3 hosts, 3 clusters, 5 services for each cluster
-    """
-    # TODO: In the future use pre-filled ADCM
-
-    cluster_bundle = sdk_client_fs.upload_from_fs(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "testdata/bundle_community/")
-    )
-    provider_bundle = sdk_client_fs.upload_from_fs(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "testdata/provider/")
-    )
-    for i in range(6):
-        provider = provider_bundle.provider_prototype().provider_create(f"provider_{i}")
-        cluster: Cluster = cluster_bundle.cluster_prototype().cluster_create(name=f"cluster_{i}")
-        hosts = [provider.host_create(fqdn=f"host_{provider.name}_{n}") for n in range(6)]
-        hc_list = []
-        for host in hosts:
-            cluster.host_add(host)
-            # Now we have service_[1..3] in cluster template
-            for j in range(1, 4):
-                service: Service = get_or_add_service(cluster, f"service_{j}")
-                for component in service.component_list():
-                    hc_list.append((host, component))
-        cluster.hostcomponent_set(*hc_list)
-    return sdk_client_fs
-
-
-@pytest.fixture()
-def adcm_api_fs(prepare_basic_adcm_data) -> ADCMTestApiWrapper:  # pylint: disable=redefined-outer-name
+def adcm_api_fs(sdk_client_fs) -> ADCMTestApiWrapper:  # pylint: disable=redefined-outer-name
     """Runs ADCM container with previously initialized image.
     Returns authorized instance of ADCMTestApiWrapper object
     """
-    return ADCMTestApiWrapper(adcm_api_wrapper=prepare_basic_adcm_data._api)  # pylint: disable=protected-access
+    return ADCMTestApiWrapper(adcm_api_wrapper=sdk_client_fs._api)  # pylint: disable=protected-access
 
 
 @pytest.fixture()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -15,26 +15,17 @@
 import allure
 import pytest
 
+from tests.conftest import DUMMY_DATA_PARAM
 from tests.api.steps.asserts import BodyAssertionError
 from tests.api.steps.common import assume_step
 from tests.api.utils.api_objects import ADCMTestApiWrapper
 
 
-@allure.title("Additional ADCM init config")
-@pytest.fixture(
-    scope="session",
-    params=[
-        pytest.param({"fill_dummy_data": True}, id="adcm_with_dummy_data"),
-    ],
-)
-def additional_adcm_init_config(request) -> dict:
+def pytest_generate_tests(metafunc):
     """
-    Add options for ADCM init.
-    Redefine this fixture in the actual project to alter additional options of ADCM initialisation.
-    Ex. If this fixture will return {"fill_dummy_data": True}
-    then on the init stage dummy objects will be added to ADCM image
+    Parametrize tests to use ADCM with dummy data
     """
-    return request.param
+    metafunc.parametrize("additional_adcm_init_config", [DUMMY_DATA_PARAM], scope="session")
 
 
 def pytest_addoption(parser):

--- a/tests/api/testdata/getters.py
+++ b/tests/api/testdata/getters.py
@@ -31,8 +31,8 @@ def get_endpoint_data(adcm: ADCMTestApiWrapper, endpoint: Endpoints) -> list:
     )
     if isinstance(res.json(), list):
         return res.json()
-        # New endpoints always return a response with pagination.
-        # In the future all endpoints will return that
+    # New endpoints always return a response with pagination.
+    # In the future all endpoints will return that
     return res.json().get("results")
 
 

--- a/tests/api/testdata/getters.py
+++ b/tests/api/testdata/getters.py
@@ -31,8 +31,8 @@ def get_endpoint_data(adcm: ADCMTestApiWrapper, endpoint: Endpoints) -> list:
     )
     if isinstance(res.json(), list):
         return res.json()
-    # New endpoints always return a response with pagination.
-    # In the future all endpoints will return that
+        # New endpoints always return a response with pagination.
+        # In the future all endpoints will return that
     return res.json().get("results")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ DUMMY_CLUSTER_BUNDLE = [
 
 CLEAN_ADCM_PARAM = pytest.param({}, id="clean_adcm")
 DUMMY_DATA_PARAM = pytest.param({"fill_dummy_data": True}, id="adcm_with_dummy_data")
+DUMMY_DATA_FULL_PARAM = pytest.param({"fill_dummy_data": True}, id="adcm_with_dummy_data", marks=[pytest.mark.full])
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,12 @@ def pytest_runtest_setup(item: Function):
     _override_allure_test_parameters(item)
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(session, config, items):  # pylint: disable=unused-argument
+    """Run tests with id "adcm_with_dummy_data" after everything else"""
+    items.sort(key=lambda x: 'adcm_with_dummy_data' in x.name)
+
+
 def _override_allure_test_parameters(item: Function):
     """
     Overrides all pytest parameters in allure report with test ID

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,9 @@ DUMMY_CLUSTER_BUNDLE = [
     }
 ]
 
+CLEAN_ADCM_PARAM = pytest.param({}, id="clean_adcm")
+DUMMY_DATA_PARAM = pytest.param({"fill_dummy_data": True}, id="adcm_with_dummy_data")
+
 
 def pytest_generate_tests(metafunc):
     """

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,27 +1,23 @@
 """Common fixtures for the functional tests"""
 import pytest
-import allure
 
-only_clean_adcm = pytest.mark.parametrize(
-    "additional_adcm_init_config",
-    [pytest.param({}, id="clean_adcm")],
-    indirect=True,
-)
+from tests.conftest import CLEAN_ADCM_PARAM, DUMMY_DATA_PARAM
+
+only_clean_adcm = pytest.mark.only_clean_adcm
 
 
-@allure.title("Additional ADCM init config")
-@pytest.fixture(
-    scope="session",
-    params=[
-        pytest.param({}, id="clean_adcm"),
-        pytest.param({"fill_dummy_data": True}, id="adcm_with_dummy_data", marks=[pytest.mark.full]),
-    ],
-)
-def additional_adcm_init_config(request) -> dict:
+CLEAN_ADCM_PARAMS = [CLEAN_ADCM_PARAM]
+CLEAN_AND_DIRTY_PARAMS = [CLEAN_ADCM_PARAM, DUMMY_DATA_PARAM]
+
+
+def pytest_generate_tests(metafunc):
     """
-    Add options for ADCM init.
-    Redefine this fixture in the actual project to alter additional options of ADCM initialisation.
-    Ex. If this fixture will return {"fill_dummy_data": True}
-    then on the init stage dummy objects will be added to ADCM image
+    Parametrize tests
     """
-    return request.param
+    if "additional_adcm_init_config" in metafunc.fixturenames:
+        if "only_clean_adcm" in metafunc.definition.own_markers:
+            values = CLEAN_ADCM_PARAMS
+        else:
+            values = CLEAN_AND_DIRTY_PARAMS
+
+        metafunc.parametrize("additional_adcm_init_config", values, scope="session")

--- a/tests/functional/test_adcm_upgrade.py
+++ b/tests/functional/test_adcm_upgrade.py
@@ -102,7 +102,7 @@ def _check_encryption(obj: Union[Cluster, Service]) -> None:
 
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
-@pytest.mark.parametrize("image", old_adcm_images(), ids=repr, indirect=True)
+@pytest.mark.parametrize("image", old_adcm_images(), ids=repr)
 def test_upgrade_adcm(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,
@@ -121,7 +121,8 @@ def test_upgrade_adcm(
 
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
-@pytest.mark.parametrize("image", old_adcm_images(), ids=repr, indirect=True)
+@pytest.mark.parametrize("image", old_adcm_images(), ids=repr)
+@pytest.mark.skip()
 def test_pass_in_config_encryption_after_upgrade(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,
@@ -144,6 +145,7 @@ def test_pass_in_config_encryption_after_upgrade(
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
 @pytest.mark.parametrize("image", [["hub.arenadata.io/adcm/adcm", "2021.06.17.06"]], ids=repr, indirect=True)
+@pytest.mark.skip()
 def test_actions_availability_after_upgrade(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,

--- a/tests/functional/test_adcm_upgrade.py
+++ b/tests/functional/test_adcm_upgrade.py
@@ -122,7 +122,6 @@ def test_upgrade_adcm(
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
 @pytest.mark.parametrize("image", old_adcm_images(), ids=repr)
-@pytest.mark.skip()
 def test_pass_in_config_encryption_after_upgrade(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,
@@ -145,7 +144,6 @@ def test_pass_in_config_encryption_after_upgrade(
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
 @pytest.mark.parametrize("image", [["hub.arenadata.io/adcm/adcm", "2021.06.17.06"]], ids=repr, indirect=True)
-@pytest.mark.skip()
 def test_actions_availability_after_upgrade(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,

--- a/tests/functional/test_adcm_upgrade.py
+++ b/tests/functional/test_adcm_upgrade.py
@@ -102,7 +102,7 @@ def _check_encryption(obj: Union[Cluster, Service]) -> None:
 
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
-@pytest.mark.parametrize("image", old_adcm_images(), ids=repr)
+@pytest.mark.parametrize("image", old_adcm_images(), ids=repr, indirect=True)
 def test_upgrade_adcm(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,
@@ -121,7 +121,7 @@ def test_upgrade_adcm(
 
 
 @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
-@pytest.mark.parametrize("image", old_adcm_images(), ids=repr)
+@pytest.mark.parametrize("image", old_adcm_images(), ids=repr, indirect=True)
 def test_pass_in_config_encryption_after_upgrade(
     adcm_fs: ADCM,
     sdk_client_fs: ADCMClient,

--- a/tests/functional/test_adcm_upgrade.py
+++ b/tests/functional/test_adcm_upgrade.py
@@ -230,6 +230,7 @@ class TestUpgradeFilledADCM:
     # Test itself
 
     @params.including_https
+    @pytest.mark.full()
     @pytest.mark.parametrize("adcm_is_upgradable", [True], indirect=True)
     @pytest.mark.parametrize("image", [previous_adcm_version_tag()], indirect=True)
     def test_upgrade_dirty_adcm(

--- a/tests/functional/test_backend_filtering.py
+++ b/tests/functional/test_backend_filtering.py
@@ -214,6 +214,7 @@ def test_coreapi_schema(sdk_client_fs: ADCMClient, tested_class: Type[BaseAPIObj
             )
 
 
+@pytest.mark.full()
 @pytest.mark.parametrize(
     ('sdk_client', 'tested_class'),
     [
@@ -508,38 +509,6 @@ def task_status_attr():
 def job_task_id_attr(host_ok_action: Action):
     """Get task task_id attr"""
     return {'task_id': host_ok_action.task().task_id}
-
-
-# There is no paging on Actions right now.
-# @pytest.mark.parametrize(
-#     "TestedParentClass",
-#     [
-#         pytest.param(
-#             lazy_fixture('cluster_with_actions'),
-#             id="Cluster"
-#         ),
-#         pytest.param(
-#             lazy_fixture('service_with_actions'),
-#             id="Service"
-#         ),
-#         pytest.param(
-#             lazy_fixture('provider_with_actions'),
-#             id="Provider"
-#         ),
-#         pytest.param(
-#             lazy_fixture('host_with_actions'),
-#             id="Host"
-#         ),
-#     ])
-# def test_paging_fail_on_actions(TestedParentClass):
-#     """Scenario:
-#     * Create object  with a lot of actions
-#     * Call action_list()
-#     * Expecting to have ResponseTooLong error
-#     """
-#     with pytest.raises(ResponseTooLong):
-#         from pprint import pprint
-#         pprint(TestedParentClass.action_list())
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_config_groups.py
+++ b/tests/functional/test_config_groups.py
@@ -554,6 +554,7 @@ class TestChangeGroupsConfig:
                     run_cluster_action_and_assert_result(cluster, action=ACTION_NAME, config=config_updated)
                     run_cluster_action_and_assert_result(cluster, action=ACTION_MULTIJOB_NAME, config=config_updated)
 
+    @pytest.mark.full()
     def test_change_group_in_service(self, cluster_bundle, cluster_with_components):
         """Test that groups in service are allowed change"""
 
@@ -593,6 +594,7 @@ class TestChangeGroupsConfig:
                     run_service_action_and_assert_result(service, action=ACTION_NAME, config=config_updated)
                     run_service_action_and_assert_result(service, action=ACTION_MULTIJOB_NAME, config=config_updated)
 
+    @pytest.mark.full()
     def test_change_group_in_component(self, cluster_bundle, cluster_with_components):
         """Test that groups in component are allowed change"""
 
@@ -637,6 +639,7 @@ class TestChangeGroupsConfig:
                         component, action=ACTION_MULTIJOB_NAME, config=config_updated
                     )
 
+    @pytest.mark.full()
     @pytest.mark.parametrize(
         "provider_bundle",
         [

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -4,3 +4,4 @@ markers =
     smoke: mark tests that covers the very basic functionality
     negative: marks tests as negative (deselect with '-m "not negative"')
     positive: marks tests as positive (select only positive with '-m "positive"')
+    only_clean_adcm: mark a test/module to run it only with clean ADCM

--- a/tests/ui_tests/conftest.py
+++ b/tests/ui_tests/conftest.py
@@ -26,6 +26,7 @@ from _pytest.fixtures import SubRequest
 from adcm_client.wrappers.docker import ADCM
 from selenium.common.exceptions import WebDriverException
 
+from tests.conftest import CLEAN_ADCM_PARAM
 from tests.ui_tests.app.api import ADCMDirectAPIClient
 from tests.ui_tests.app.app import ADCMTest
 from tests.ui_tests.app.page.admin.page import AdminIntroPage
@@ -34,21 +35,12 @@ from tests.ui_tests.app.page.login.page import LoginPage
 SELENOID_DOWNLOADS_PATH = '/home/selenium/Downloads'
 
 
-@allure.title("Additional ADCM init config")
-@pytest.fixture(
-    scope="session",
-    params=[
-        pytest.param({}, id="clean_adcm"),
-    ],
-)
-def additional_adcm_init_config(request) -> dict:
+def pytest_generate_tests(metafunc):
     """
-    Add options for ADCM init.
-    Redefine this fixture in the actual project to alter additional options of ADCM initialisation.
-    Ex. If this fixture will return {"fill_dummy_data": True}
-    then on the init stage dummy objects will be added to ADCM image
+    Parametrize for running tests on clean ADCM only
     """
-    return request.param
+    if "additional_adcm_init_config" in metafunc.fixturenames:
+        metafunc.parametrize("additional_adcm_init_config", [CLEAN_ADCM_PARAM], scope="session")
 
 
 @pytest.fixture(scope="session")

--- a/tests/ui_tests/test_configs.py
+++ b/tests/ui_tests/test_configs.py
@@ -23,6 +23,8 @@ from adcm_pytest_plugin.utils import random_string
 
 from tests.ui_tests.utils import prepare_cluster_and_get_config
 
+pytestmark = [pytest.mark.full()]
+
 PAIR = (True, False)
 UI_OPTIONS_PAIRS = ((False, False), (False, True), (True, False))
 UI_OPTIONS_PAIRS_GROUPS = [

--- a/tests/ui_tests/test_ui_config_hell.py
+++ b/tests/ui_tests/test_ui_config_hell.py
@@ -68,6 +68,7 @@ def ui_display_names(
     return Configuration.from_service(app_fs, ui_hell_fs).get_display_names()
 
 
+@pytest.mark.full()
 def test_save_configuration_hell(
     config_page: ServiceConfigPage,
     prototype_display_names: Tuple[str, str],


### PR DESCRIPTION
This PR is dedicated to speeding up "branch to develop" tests run.

To achieve it two things were done:
1. Some tests were marked as "full" because they take too much time or cover corner cases.
2. API tests were reworked to use "ADCM with dummy data" to skip the phase of pre-filling ADCM that takes about a minute for each test.

Also, the process of choosing which ADCM to use (clean or with dummy data) was reworked so it can be used in API tests the same way as it is used in functional and UI tests.