### PR TITLE
ADCM-2574 skip mark removed from `before_upgrade` upgrade tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://ci.arenadata.io/artifactory/api/pypi/python-packages/simple
-adcm-client>=2021.7.21
+adcm-client>=2022.1.20.14
 adcm-pytest-plugin~=4.14
 attr
 allure-pytest

--- a/tests/functional/test_upgrade_cluster.py
+++ b/tests/functional/test_upgrade_cluster.py
@@ -176,7 +176,6 @@ def test_cannot_upgrade_with_state(sdk_client_fs: ADCMClient, old_bundle):
         UPGRADE_ERROR.equal(e, 'cluster state', 'is not in available states list')
 
 
-@pytest.mark.skip(reason="Need new version of ADCM client")
 @pytest.mark.usefixtures("upgradable_bundle")
 def test_before_upgrade_state(old_bundle):
     """Test that field "before_upgrade" field has correct values"""


### PR DESCRIPTION
Waiting for [this PR](https://github.com/arenadata/adcm_client/pull/107)