### PR TITLE
ADCM-2648 Adopt tests for new RBAC view logic

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://ci.arenadata.io/artifactory/api/pypi/python-packages/simple
-adcm_client>=2022.1.27.13
+adcm_client>=2022.2.15.17rc109
 adcm-pytest-plugin~=4.14
 attr
 allure-pytest

--- a/tests/functional/rbac/actions/test_run_actions.py
+++ b/tests/functional/rbac/actions/test_run_actions.py
@@ -15,9 +15,7 @@
 # pylint: disable=too-many-locals
 
 import itertools
-from collections import defaultdict
-from contextlib import contextmanager
-from typing import Type, Dict, Optional, List, Union, Callable, Tuple, Generator
+from typing import Optional, Union, Tuple
 
 import allure
 import pytest
@@ -79,24 +77,18 @@ def _test_basic_action_run_permissions(adcm_object, admin_sdk, user_sdk, user, a
     with allure.step(
         f'Check that granting policy allows to run action "{DO_NOTHING_ACTION}" on {get_object_represent(adcm_object)}'
     ):
-        (user_object,) = as_user_objects(user_sdk, adcm_object)
         business_role = action_business_role(adcm_object, DO_NOTHING_ACTION)
         policy = create_action_policy(admin_sdk, adcm_object, business_role, user=user)
 
         check_single_action_is_allowed_on_object(DO_NOTHING_ACTION, adcm_object, user_sdk, business_role)
 
     with allure.step(f"Check that granted permission doesn't allow running '{DO_NOTHING_ACTION}' on other objects"):
-        with user_objects_map(
-            user_sdk,
-            [adcm_object],
-            *all_objects,
-            exclude_predicate=_do_nothing_action_not_presented,
-        ) as objects_map:
-            check_action_is_not_allowed_on_objects(DO_NOTHING_ACTION, objects_map)
+        for obj in filter(lambda x: not _do_nothing_action_not_presented(x), all_objects):
+            is_denied(obj, action_business_role(obj, DO_NOTHING_ACTION), client=user_sdk)
 
     with allure.step('Check permission withdrawn'):
         delete_policy(policy)
-        is_denied(user_object, business_role)
+        is_denied(adcm_object, business_role, client=user_sdk)
 
 
 @pytest.mark.extra_rbac()
@@ -105,26 +97,27 @@ def test_config_change_via_plugin(clients, user, actions_cluster, actions_provid
     Test that permission on action run is enough for changing configuration with plugins.
     Config change action has its own config.
     """
-    cluster, service, component = as_user_objects(
-        clients.user,
-        actions_cluster,
-        (serv := actions_cluster.service(name='config_changing_service')),
-        serv.component(name='config_changing_component'),
+    cluster = actions_cluster
+    service = actions_cluster.service(name='config_changing_service')
+    component = service.component(name='config_changing_component')
+
+    provider, host = actions_provider, actions_provider.host()
+
+    _test_config_change(cluster, (cluster,), user=user, user_client=clients.user, admin_client=clients.admin)
+    _test_config_change(service, (cluster, service), user=user, user_client=clients.user, admin_client=clients.admin)
+    _test_config_change(
+        component, (cluster, service, component), user=user, user_client=clients.user, admin_client=clients.admin
     )
-    provider, host = as_user_objects(clients.user, actions_provider, actions_provider.host())
 
-    _test_config_change(cluster, (cluster,), user=user, admin_client=clients.admin)
-    _test_config_change(service, (cluster, service), user=user, admin_client=clients.admin)
-    _test_config_change(component, (cluster, service, component), user=user, admin_client=clients.admin)
-
-    _test_config_change(provider, (provider,), user=user, admin_client=clients.admin)
-    _test_config_change(host, (provider, host), user=user, admin_client=clients.admin)
+    _test_config_change(provider, (provider,), user=user, user_client=clients.user, admin_client=clients.admin)
+    _test_config_change(host, (provider, host), user=user, user_client=clients.user, admin_client=clients.admin)
 
 
 def _test_config_change(
     action_owner_object: AnyADCMObject,
     objects_to_change: Tuple[AnyADCMObject, ...],
     admin_client: ADCMClient,
+    user_client: ADCMClient,
     user: User,
 ) -> None:
     """
@@ -147,13 +140,13 @@ def _test_config_change(
         f'Apply policy on "{owner_object_represent}" and check config change is allowed without explicit permission'
     ):
         policy = create_action_policy(admin_client, action_owner_object, *business_roles, user=user)
+        user_object, *_ = as_user_objects(user_client, action_owner_object)
 
-        for adcm_object, business_role in object_role_map:
-            admin_object = as_user_objects(admin_client, adcm_object)[0]
+        for admin_object, business_role in object_role_map:
             config_field_value = admin_object.config()[CONFIG_FIELD_TO_CHANGE]
-            new_value = f'{config_field_value}_{adcm_object.__class__.__name__}'
+            new_value = f'{config_field_value}_{admin_object.__class__.__name__}'
             with allure.step(f'Try to change {get_object_represent(admin_object)} from {owner_object_represent}'):
-                task = is_allowed(action_owner_object, business_role, config={ACTION_CONFIG_ARGUMENT: new_value})
+                task = is_allowed(user_object, business_role, config={ACTION_CONFIG_ARGUMENT: new_value})
                 assert task.wait() == 'success', 'Action should succeeded'
                 assert (
                     admin_object.config()[CONFIG_FIELD_TO_CHANGE] == new_value
@@ -161,11 +154,15 @@ def _test_config_change(
 
     with allure.step('Delete policy and check actions are denied and config stays the same'):
         delete_policy(policy)
-        for adcm_object, business_role in object_role_map:
-            admin_object = as_user_objects(admin_client, adcm_object)[0]
+        for admin_object, business_role in object_role_map:
             with allure.step(f'Try to change {get_object_represent(admin_object)} from {owner_object_represent}'):
                 config_val_before = admin_object.config()[CONFIG_FIELD_TO_CHANGE]
-                is_denied(action_owner_object, business_role, config={ACTION_CONFIG_ARGUMENT: "This you seen't"})
+                is_denied(
+                    action_owner_object,
+                    business_role,
+                    config={ACTION_CONFIG_ARGUMENT: "This you seen't"},
+                    client=user_client,
+                )
                 config_val_after = admin_object.config()[CONFIG_FIELD_TO_CHANGE]
                 assert (
                     config_val_before == config_val_after
@@ -193,15 +190,14 @@ def test_host_actions(clients, actions_cluster, actions_cluster_bundle, actions_
             component = service.component(name=component_name)
             cluster.hostcomponent_set((host, component))
 
-    host, second_host = as_user_objects(clients.user, first_host, second_host)
-    cluster, _, _ = user_cluster_objects = as_user_objects(
-        clients.user, actions_cluster, actions_service, single_component
-    )
+    cluster, *_ = cluster_objects = actions_cluster, actions_service, single_component
 
     with allure.step('Grant permission to run host actions on cluster, service and component'):
         business_roles = [
-            action_business_role(obj, host_action_template.format(object_type=obj.__class__.__name__))
-            for obj in user_cluster_objects
+            action_business_role(
+                obj, host_action_template.format(object_type=obj.__class__.__name__), action_on_host=first_host
+            )
+            for obj in cluster_objects
         ]
         policy = create_action_policy(
             clients.admin,
@@ -210,34 +206,40 @@ def test_host_actions(clients, actions_cluster, actions_cluster_bundle, actions_
             user=user,
         )
 
+        host, *_ = as_user_objects(clients.user, first_host)
+
     with allure.step('Run host actions from cluster, service and component on host in and out of cluster'):
         for role in business_roles:
             is_allowed(host, role).wait()
-            is_denied(second_host, role)
+            is_denied(second_host, role, client=clients.user)
 
     with allure.step('Check policy deletion leads to denial of host action execution'):
         delete_policy(policy)
         for role in business_roles:
-            is_denied(host, role)
-            is_denied(second_host, role)
+            is_denied(first_host, role, client=clients.user)
+            is_denied(second_host, role, client=clients.user)
 
 
 @pytest.mark.extra_rbac()
 def test_action_on_host_available_with_cluster_parametrization(clients, actions_cluster, actions_provider, user):
     """Test that host owned action is still available"""
     admin_host = actions_provider.host()
-    actions_cluster.host_add(admin_host)
-    user_cluster, user_host = as_user_objects(clients.user, actions_cluster, admin_host)
+    admin_cluster = actions_cluster
+    admin_cluster.host_add(admin_host)
+
     cluster_business_role, host_business_role = action_business_role(
-        user_cluster, DO_NOTHING_ACTION
-    ), action_business_role(user_host, DO_NOTHING_ACTION)
-    policy = create_action_policy(clients.admin, user_cluster, cluster_business_role, host_business_role, user=user)
+        admin_cluster, DO_NOTHING_ACTION
+    ), action_business_role(admin_host, DO_NOTHING_ACTION)
+    policy = create_action_policy(clients.admin, admin_cluster, cluster_business_role, host_business_role, user=user)
+
+    user_cluster, user_host = as_user_objects(clients.user, actions_cluster, admin_host)
+
     is_allowed(user_cluster, cluster_business_role).wait()
     is_allowed(user_host, host_business_role).wait()
 
     delete_policy(policy)
-    is_denied(user_cluster, cluster_business_role)
-    is_denied(user_host, host_business_role)
+    is_denied(admin_cluster, cluster_business_role, client=clients.user)
+    is_denied(admin_host, host_business_role, client=clients.user)
 
 
 # !===== Steps and checks =====!
@@ -251,63 +253,15 @@ def check_single_action_is_allowed_on_object(
     business_role: Optional[BusinessRole] = None,
 ):
     """Check that only one action is allowed on object and the access to others is denied"""
-    (allowed_object,) = as_user_objects(user_sdk, adcm_object)
+    allowed_object, *_ = as_user_objects(user_sdk, adcm_object)
     business_role = business_role or action_business_role(allowed_object, action_display_name)
 
     is_allowed(allowed_object, business_role).wait()
     for action_name in (a.display_name for a in adcm_object.action_list() if a.display_name != action_display_name):
-        is_denied(allowed_object, action_business_role(allowed_object, action_name))
-
-
-@allure.step("Check actions aren't allowed on objects they don't suppose to")
-def check_action_is_not_allowed_on_objects(action_display_name: str, objects_to_deny: Dict[Type, Dict[int, object]]):
-    """Check that provided action (by display name) is not allowed to run on any of provided objects"""
-    for object_map in objects_to_deny.values():
-        for adcm_object in object_map.values():
-            is_denied(adcm_object, action_business_role(adcm_object, action_display_name))
+        is_denied(adcm_object, action_business_role(adcm_object, action_name), client=user_sdk)
 
 
 # !===== Utilities =====!
-
-
-@contextmanager
-def user_objects_map(
-    user_sdk,
-    exclude_objects: List[AnyADCMObject],
-    *objects: AnyADCMObject,
-    exclude_predicate: Callable[[AnyADCMObject], bool] = None,
-) -> Generator[Dict[Type, Dict[int, AnyADCMObject]], None, None]:
-    """
-    Get objects map in format:
-    {
-      classname: {
-        object_id: object (from user sdk)
-      }
-    }
-
-    Inside the context following objects are removed from map:
-    1. Ones that are listed in `exclude_objects`.
-    2. Ones that satisfies the exclude_predicate.
-    After the context is left all excluded objects are returned to the map.
-
-    P.S. You can improve this manager by adding `full_map` argument that will operate on existing map
-         (if you'll need to reuse map that was constructed during previous call).
-    """
-    full_map = defaultdict(dict)
-    user_objects = as_user_objects(user_sdk, *objects)
-
-    for obj in user_objects:
-        full_map[obj.__class__][obj.id] = obj
-
-    filtered = list(filter(exclude_predicate, user_objects)) if exclude_predicate else []
-
-    exclude_set = set((obj.__class__, obj.id) for obj in (exclude_objects + filtered))
-    excluded = tuple((full_map[cls].pop(object_id) for cls, object_id in exclude_set))
-
-    yield full_map
-
-    for obj in excluded:
-        full_map[obj.__class__][obj.id] = obj
 
 
 def get_all_cluster_tree_plain(cluster: Cluster) -> Tuple[Union[Cluster, Service, Component], ...]:

--- a/tests/functional/rbac/checkers.py
+++ b/tests/functional/rbac/checkers.py
@@ -1,0 +1,183 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checker for checking if performing some actions is truly denied"""
+
+import json
+import re
+from functools import partial
+from typing import Type, Collection, Union, Callable, Optional
+from urllib import parse
+
+import allure
+import requests
+from adcm_client.base import ObjectNotFound
+from adcm_client.objects import (
+    ADCMClient,
+    Cluster,
+    Service,
+    Component,
+    Provider,
+    Host,
+    User,
+    Group,
+    Role,
+    Policy,
+    Bundle,
+    ADCM,
+)
+
+from tests.library.consts import HTTPMethod
+from tests.functional.tools import AnyADCMObject, AnyRBACObject
+
+RoleTargetObject = Union[AnyADCMObject, AnyRBACObject, Bundle, ADCM]
+RoleTargetType = Type[RoleTargetObject]
+
+
+class ForbiddenCallChecker:  # pylint: disable=too-few-public-methods
+    """Helper to check that certain interaction with an ADCM object is truly forbidden via API"""
+
+    _API_ROOT = '/api/v1/'
+
+    # this regex should match word characters between { and } that ends in "id"
+    _format_id_arg_regexp = re.compile(r'{(\w*id)}')
+    _method_map = {
+        ADCM: 'adcm/{id}/',
+        Bundle: 'stack/bundle/{id}/',
+        Cluster: 'cluster/{id}/',
+        Service: 'cluster/{cluster_id}/service/{id}/',
+        Component: 'cluster/{cluster_id}/service/{service_id}/component/{id}/',
+        Provider: 'provider/{id}/',
+        Host: 'provider/{provider_id}/host/{id}/',
+        User: 'rbac/user/{id}/',
+        Group: 'rbac/group/{id}/',
+        Role: 'rbac/role/{id}/',
+        Policy: 'rbac/policy/{id}/',
+        # TODO jobs, tasks?
+    }
+
+    # first argument is adcm_object, should allow passing kwargs
+    _get_infix: Callable[..., str]
+    is_of_correct_type: Callable[[RoleTargetObject], bool]
+
+    def __init__(
+        self,
+        object_type: Union[RoleTargetType, Collection[RoleTargetType]],
+        endpoint_suffix: str,
+        method: HTTPMethod,
+        *,
+        special_case: Optional[str] = None,
+    ):
+        if special_case:
+            # rework to switch maybe if you have time
+            # and maybe add enum to list all possible cases not in string form
+            __special_cases = {
+                'create-from-bundle': self._format_create_from_bundle_infix,
+                'host-on-cluster': self._format_host_on_cluster_infix,
+                'upgrade': self._format_infix_for_upgrade,
+            }
+            self._get_infix = __special_cases[special_case]
+        else:
+            self._get_infix = self._format_infix
+        if isinstance(object_type, Collection):
+            self.is_of_correct_type = lambda obj: obj.__class__ in object_type
+        else:
+            self.is_of_correct_type = lambda obj: obj.__class__ == object_type
+        self.object_type = object_type
+        self.url_suffix = endpoint_suffix.lstrip('/')
+        self.method = method
+
+    def __call__(self, client: ADCMClient, adcm_object: AnyADCMObject, *args, **kwargs):
+        suffix = f'{self._get_infix(adcm_object, client=client)}{self.url_suffix}/'
+        url = parse.urljoin(client.url, f'{self._API_ROOT}{suffix}')
+        call_api_method = getattr(requests, self.method.value)
+        with allure.step(f'Send {self.method.name} request to {url}'):
+            response: requests.Response = call_api_method(
+                url,
+                headers={
+                    'Authorization': f'Token {client.api_token()}',
+                    'Content-Type': 'application/json',
+                },
+            )
+        if (status_code := response.status_code) >= 500:
+            raise AssertionError(f'Unhandled exception on {self.method.name} call to {url} check logs')
+        if status_code != 403:
+            try:
+                body = json.dumps(response.json(), indent=4)
+                attachment_type = allure.attachment_type.JSON
+            except requests.exceptions.JSONDecodeError:
+                body = response.text
+                attachment_type = allure.attachment_type.HTML
+            allure.attach(name=f'Response on call to {url}', body=body, attachment_type=attachment_type)
+            raise AssertionError(
+                f'Unexpected status code, call to {url} should be denied, but status code was {status_code}'
+            )
+
+    def _format_infix(self, adcm_object: RoleTargetObject, **_) -> str:
+        self._raise_on_incorrect_type(adcm_object)
+        infix_template = self._method_map[adcm_object.__class__]
+        template_format_arguments = {
+            format_arg: getattr(adcm_object, format_arg)
+            for format_arg in self._format_id_arg_regexp.findall(infix_template)
+        }
+        return infix_template.format(**template_format_arguments)
+
+    def _format_host_on_cluster_infix(self, adcm_object: Host, **_):  # pylint: disable=no-self-use
+        if not isinstance(adcm_object, Host) or not adcm_object.cluster_id:
+            raise ValueError(f'Object {adcm_object} should be of type Host and be bond to a cluster')
+        return f'cluster/{adcm_object.cluster_id}/host/{adcm_object.id}/'
+
+    def _format_infix_for_upgrade(self, adcm_object, **_):
+        self._raise_on_incorrect_type(adcm_object)
+        # upgrade only for cluster, provider, so nothing but id matters
+        object_suffix = self._method_map[adcm_object.__class__].format(id=adcm_object.id)
+        # we assume that it's always the first
+        return f'{object_suffix}upgrade/1/do'
+
+    def _format_create_from_bundle_infix(self, adcm_object, **_):
+        self._raise_on_incorrect_type(adcm_object)
+        try:
+            adcm_object.cluster_prototype()
+            return 'cluster/'
+        except ObjectNotFound:
+            return 'provider/'
+
+    def _raise_on_incorrect_type(self, adcm_object):
+        if not self.is_of_correct_type(adcm_object):
+            raise ValueError(f'Object {adcm_object} should be of type {self.object_type}')
+
+
+def _deny_endpoint_call(endpoint: str, method: HTTPMethod):
+    return partial(ForbiddenCallChecker, endpoint_suffix=endpoint, method=method)
+
+
+class Deny:  # pylint: disable=too-few-public-methods
+    """Description of possible "deny" checks"""
+
+    ViewConfigOf = _deny_endpoint_call('config', HTTPMethod.GET)
+    ChangeConfigOf = _deny_endpoint_call('config/history', HTTPMethod.POST)
+    AddServiceToCluster = ForbiddenCallChecker(Cluster, '', HTTPMethod.POST)
+    RemoveServiceFromCluster = ForbiddenCallChecker(Cluster, '', HTTPMethod.DELETE)
+    AddHostToCluster = ForbiddenCallChecker(Cluster, 'host', HTTPMethod.POST)
+    RemoveHostFromCluster = ForbiddenCallChecker(Host, '', HTTPMethod.DELETE, special_case='host-on-cluster')
+    Delete = _deny_endpoint_call('', HTTPMethod.DELETE)
+    ViewImportsOf = _deny_endpoint_call('import', HTTPMethod.GET)
+    ManageImportsOf = _deny_endpoint_call('bind', HTTPMethod.POST)
+    ViewHostComponentOf = _deny_endpoint_call('hostcomponent', HTTPMethod.GET)
+    EditHostComponentOf = _deny_endpoint_call('hostcomponent', HTTPMethod.POST)
+    # here we let special case to fully build suffix
+    CreateCluster = ForbiddenCallChecker(Bundle, '', HTTPMethod.POST, special_case='create-from-bundle')
+    CreateProvider = ForbiddenCallChecker(Bundle, '', HTTPMethod.POST, special_case='create-from-bundle')
+    CreateHost = ForbiddenCallChecker(Provider, 'host', HTTPMethod.POST)
+    UpgradeProvider = ForbiddenCallChecker(Provider, '', HTTPMethod.POST, special_case='upgrade')
+    UpgradeCluster = ForbiddenCallChecker(Cluster, '', HTTPMethod.POST, special_case='upgrade')
+    Change = _deny_endpoint_call('', HTTPMethod.PUT)  # change user, role, etc

--- a/tests/functional/rbac/test_adcm_related_permissions.py
+++ b/tests/functional/rbac/test_adcm_related_permissions.py
@@ -23,62 +23,62 @@ from tests.functional.rbac.conftest import (
     is_denied,
     is_allowed,
     delete_policy,
-    as_user_objects,
 )
 
 pytestmark = [pytest.mark.extra_rbac]
 
 
 @use_role(BusinessRoles.ViewADCMSettings)
-def test_view_adcm_settings(user_policy, user_sdk: ADCMClient, prepare_objects):
+def test_view_adcm_settings(user_policy, user_sdk: ADCMClient, prepare_objects, is_denied_to_user):
     """Test that View ADCM Settings role is ok"""
-    (cluster,) = as_user_objects(user_sdk, prepare_objects[0])
+    cluster, *_ = prepare_objects
 
     is_allowed(user_sdk.adcm(), BusinessRoles.ViewADCMSettings)
-    is_denied(user_sdk.adcm(), BusinessRoles.EditADCMSettings)
-    is_denied(cluster, BusinessRoles.ViewClusterConfigurations)
+    is_denied_to_user(user_sdk.adcm(), BusinessRoles.EditADCMSettings)
+    is_denied_to_user(cluster, BusinessRoles.ViewClusterConfigurations)
 
     delete_policy(user_policy)
-    is_denied(user_sdk.adcm(), BusinessRoles.ViewADCMSettings)
+    is_denied_to_user(user_sdk.adcm(), BusinessRoles.ViewADCMSettings)
 
 
 @use_role(BusinessRoles.EditADCMSettings)
-def test_edit_adcm_settings(user_policy, user_sdk: ADCMClient, prepare_objects):
+def test_edit_adcm_settings(user_policy, user_sdk: ADCMClient, prepare_objects, is_denied_to_user):
     """Test that Edit ADCM Settings role is ok"""
-    (cluster,) = as_user_objects(user_sdk, prepare_objects[0])
+    cluster, *_ = prepare_objects
+    adcm = user_sdk.adcm()
 
-    is_allowed(user_sdk.adcm(), BusinessRoles.ViewADCMSettings)
-    is_allowed(user_sdk.adcm(), BusinessRoles.EditADCMSettings)
-    is_denied(cluster, BusinessRoles.ViewClusterConfigurations)
+    is_allowed(adcm, BusinessRoles.ViewADCMSettings)
+    is_allowed(adcm, BusinessRoles.EditADCMSettings)
+    is_denied_to_user(cluster, BusinessRoles.ViewClusterConfigurations)
 
     delete_policy(user_policy)
-    is_denied(user_sdk.adcm(), BusinessRoles.ViewADCMSettings)
-    is_denied(user_sdk.adcm(), BusinessRoles.EditADCMSettings)
+    is_denied_to_user(adcm, BusinessRoles.ViewADCMSettings)
+    is_denied_to_user(adcm, BusinessRoles.EditADCMSettings)
 
 
 @use_role(BusinessRoles.ViewUsers)
-def test_view_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_view_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "View users" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewUsers)
     is_denied(user_sdk, BusinessRoles.CreateUser)
-    simple_user = user_sdk.user(id=sdk_client_fs.user_create(username="test", password="test").id)
-    is_denied(simple_user, BusinessRoles.EditUser)
-    is_denied(simple_user, BusinessRoles.RemoveUser)
+    simple_user = sdk_client_fs.user_create(username="test", password="test")
+    is_denied_to_user(simple_user, BusinessRoles.EditUser)
+    is_denied_to_user(simple_user, BusinessRoles.RemoveUser)
 
     delete_policy(user_policy)
     is_denied(user_sdk, BusinessRoles.ViewUsers)
 
 
 @use_role(BusinessRoles.CreateUser)
-def test_create_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_create_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Create users" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewUsers)
     is_allowed(user_sdk, BusinessRoles.CreateUser)
     simple_user = user_sdk.user(username="test")
-    is_denied(simple_user, BusinessRoles.EditUser)
-    is_denied(simple_user, BusinessRoles.RemoveUser)
+    is_denied_to_user(simple_user, BusinessRoles.EditUser)
+    is_denied_to_user(simple_user, BusinessRoles.RemoveUser)
 
     delete_policy(user_policy)
     sdk_client_fs.user(username="test").delete()
@@ -87,28 +87,28 @@ def test_create_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClie
 
 
 @use_role(BusinessRoles.EditUser)
-def test_edit_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_edit_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Edit users" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewUsers)
     is_denied(user_sdk, BusinessRoles.CreateUser)
     simple_user = user_sdk.user(id=sdk_client_fs.user_create(username="test", password="test").id)
     is_allowed(simple_user, BusinessRoles.EditUser)
-    is_denied(simple_user, BusinessRoles.RemoveUser)
+    is_denied_to_user(simple_user, BusinessRoles.RemoveUser)
 
     delete_policy(user_policy)
-    is_denied(user_sdk, BusinessRoles.ViewUsers)
-    is_denied(simple_user, BusinessRoles.EditUser)
+    is_denied_to_user(user_sdk, BusinessRoles.ViewUsers)
+    is_denied_to_user(simple_user, BusinessRoles.EditUser)
 
 
 @use_role(BusinessRoles.RemoveUser)
-def test_remove_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_remove_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Remove users" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewUsers)
     is_denied(user_sdk, BusinessRoles.CreateUser)
     simple_user = user_sdk.user(id=sdk_client_fs.user_create(username="test", password="test").id)
-    is_denied(simple_user, BusinessRoles.EditUser)
+    is_denied_to_user(simple_user, BusinessRoles.EditUser)
     is_allowed(simple_user, BusinessRoles.RemoveUser)
 
     delete_policy(user_policy)
@@ -116,27 +116,27 @@ def test_remove_users(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClie
 
 
 @use_role(BusinessRoles.ViewGroups)
-def test_view_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_view_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "View groups" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewGroups)
     is_denied(user_sdk, BusinessRoles.CreateGroup)
     simple_group = user_sdk.group(id=sdk_client_fs.group_create(name="test").id)
-    is_denied(simple_group, BusinessRoles.EditGroup)
-    is_denied(simple_group, BusinessRoles.RemoveGroup)
+    is_denied_to_user(simple_group, BusinessRoles.EditGroup)
+    is_denied_to_user(simple_group, BusinessRoles.RemoveGroup)
 
     delete_policy(user_policy)
     is_denied(user_sdk, BusinessRoles.ViewGroups)
 
 
 @use_role(BusinessRoles.CreateGroup)
-def test_create_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_create_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Create groups" role is ok"""
     is_allowed(user_sdk, BusinessRoles.ViewGroups)
     is_allowed(user_sdk, BusinessRoles.CreateGroup)
     simple_group = user_sdk.group(name="test")
-    is_denied(simple_group, BusinessRoles.EditGroup)
-    is_denied(simple_group, BusinessRoles.RemoveGroup)
+    is_denied_to_user(simple_group, BusinessRoles.EditGroup)
+    is_denied_to_user(simple_group, BusinessRoles.RemoveGroup)
 
     delete_policy(user_policy)
     sdk_client_fs.group(name="test").delete()
@@ -145,36 +145,36 @@ def test_create_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMCli
 
 
 @use_role(BusinessRoles.EditGroup)
-def test_edit_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_edit_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Edit groups" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewGroups)
     is_denied(user_sdk, BusinessRoles.CreateGroup)
     simple_group = user_sdk.group(id=sdk_client_fs.group_create(name="test").id)
     is_allowed(simple_group, BusinessRoles.EditGroup)
-    is_denied(simple_group, BusinessRoles.RemoveGroup)
+    is_denied_to_user(simple_group, BusinessRoles.RemoveGroup)
 
     delete_policy(user_policy)
-    is_denied(user_sdk, BusinessRoles.ViewGroups)
-    is_denied(simple_group, BusinessRoles.EditGroup)
+    is_denied_to_user(user_sdk, BusinessRoles.ViewGroups)
+    is_denied_to_user(simple_group, BusinessRoles.EditGroup)
 
 
 @use_role(BusinessRoles.RemoveGroup)
-def test_remove_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_remove_groups(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Remove groups" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewGroups)
     is_denied(user_sdk, BusinessRoles.CreateGroup)
     simple_group = user_sdk.group(id=sdk_client_fs.group_create(name="test").id)
-    is_denied(simple_group, BusinessRoles.EditGroup)
+    is_denied_to_user(simple_group, BusinessRoles.EditGroup)
     is_allowed(simple_group, BusinessRoles.RemoveGroup)
 
     delete_policy(user_policy)
-    is_denied(user_sdk, BusinessRoles.ViewGroups)
+    is_denied_to_user(user_sdk, BusinessRoles.ViewGroups)
 
 
 @use_role(BusinessRoles.ViewRoles)
-def test_view_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_view_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "View roles" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewRoles)
@@ -185,22 +185,22 @@ def test_view_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient
 
     BusinessRoles.CreateCustomRoles.value.method_call(sdk_client_fs)
     custom_role = user_sdk.role(name="Custom role")
-    is_denied(custom_role, BusinessRoles.EditRoles)
-    is_denied(custom_role, BusinessRoles.RemoveRoles)
+    is_denied_to_user(custom_role, BusinessRoles.EditRoles)
+    is_denied_to_user(custom_role, BusinessRoles.RemoveRoles)
 
     delete_policy(user_policy)
     is_denied(user_sdk, BusinessRoles.ViewRoles)
 
 
 @use_role(BusinessRoles.CreateCustomRoles)
-def test_create_custom_role(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_create_custom_role(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Create custom role" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewRoles)
     is_allowed(user_sdk, BusinessRoles.CreateCustomRoles)
     custom_role = user_sdk.role(name="Custom role")
-    is_denied(custom_role, BusinessRoles.EditRoles)
-    is_denied(custom_role, BusinessRoles.RemoveRoles)
+    is_denied_to_user(custom_role, BusinessRoles.EditRoles)
+    is_denied_to_user(custom_role, BusinessRoles.RemoveRoles)
 
     delete_policy(user_policy)
     sdk_client_fs.role(id=custom_role.id).delete()
@@ -208,7 +208,7 @@ def test_create_custom_role(user_policy, user_sdk: ADCMClient, sdk_client_fs: AD
 
 
 @use_role(BusinessRoles.EditRoles)
-def test_edit_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient):
+def test_edit_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient, is_denied_to_user):
     """Test that "Edit role" role is ok"""
 
     is_allowed(user_sdk, BusinessRoles.ViewRoles)
@@ -217,10 +217,10 @@ def test_edit_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClient
     BusinessRoles.CreateCustomRoles.value.method_call(sdk_client_fs)
     custom_role = user_sdk.role(name="Custom role")
     is_allowed(custom_role, BusinessRoles.EditRoles)
-    is_denied(custom_role, BusinessRoles.RemoveRoles)
+    is_denied_to_user(custom_role, BusinessRoles.RemoveRoles)
 
     delete_policy(user_policy)
-    is_denied(custom_role, BusinessRoles.EditRoles)
+    is_denied_to_user(custom_role, BusinessRoles.EditRoles)
 
 
 @use_role(BusinessRoles.RemoveRoles)
@@ -232,7 +232,7 @@ def test_remove_roles(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClie
 
     BusinessRoles.CreateCustomRoles.value.method_call(sdk_client_fs)
     custom_role = user_sdk.role(name="Custom role")
-    is_denied(custom_role, BusinessRoles.EditRoles)
+    is_denied(custom_role, BusinessRoles.EditRoles, client=user_sdk)
     is_allowed(custom_role, BusinessRoles.RemoveRoles)
 
     delete_policy(user_policy)
@@ -264,8 +264,8 @@ def test_create_policy(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMCli
     is_allowed(user_sdk, BusinessRoles.ViewPolicies)
     is_allowed(user_sdk, BusinessRoles.CreatePolicy, role=custom_role, user=[user])
     policy = user_sdk.policy(name="Test policy")
-    is_denied(policy, BusinessRoles.EditPolicy)
-    is_denied(policy, BusinessRoles.RemovePolicy)
+    is_denied(policy, BusinessRoles.EditPolicy, client=user_sdk)
+    is_denied(policy, BusinessRoles.RemovePolicy, client=user_sdk)
 
     delete_policy(user_policy)
     sdk_client_fs.policy(id=policy.id).delete()
@@ -285,11 +285,11 @@ def test_edit_policy(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMClien
         id=sdk_client_fs.policy_create(name="Test policy", objects=[], role=custom_role, user=[user]).id
     )
     is_allowed(custom_policy, BusinessRoles.EditPolicy)
-    is_denied(custom_policy, BusinessRoles.RemovePolicy)
+    is_denied(custom_policy, BusinessRoles.RemovePolicy, client=user_sdk)
 
     delete_policy(user_policy)
     is_denied(user_sdk, BusinessRoles.ViewPolicies)
-    is_denied(custom_policy, BusinessRoles.EditPolicy)
+    is_denied(custom_policy, BusinessRoles.EditPolicy, client=user_sdk)
 
 
 @use_role(BusinessRoles.RemovePolicy)
@@ -304,7 +304,7 @@ def test_remove_policy(user_policy, user_sdk: ADCMClient, sdk_client_fs: ADCMCli
     custom_policy = user_sdk.policy(
         id=sdk_client_fs.policy_create(name="Test policy", objects=[], role=custom_role, user=[user]).id
     )
-    is_denied(custom_policy, BusinessRoles.EditPolicy)
+    is_denied(custom_policy, BusinessRoles.EditPolicy, client=user_sdk)
     is_allowed(custom_policy, BusinessRoles.RemovePolicy)
 
     delete_policy(user_policy)

--- a/tests/functional/rbac/test_built_in_roles_composition.py
+++ b/tests/functional/rbac/test_built_in_roles_composition.py
@@ -53,6 +53,7 @@ SERVICE_ADMIN_ROLES = {
         BusinessRoles.EditComponentConfigurations,
         BusinessRoles.ViewHostConfigurations,
         BusinessRoles.ManageServiceImports,
+        BusinessRoles.ViewHostComponents,
     )
 }
 
@@ -71,6 +72,8 @@ CLUSTER_ADMIN_ROLES = SERVICE_ADMIN_ROLES.union(
             BusinessRoles.UpgradeClusterBundle,
             BusinessRoles.UploadBundle,
             BusinessRoles.RemoveBundle,
+            BusinessRoles.CreateHost,
+            BusinessRoles.RemoveHosts,
         )
     }
 )

--- a/tests/functional/rbac/test_cluster_related_permissions.py
+++ b/tests/functional/rbac/test_cluster_related_permissions.py
@@ -36,32 +36,41 @@ from tests.functional.rbac.conftest import (
 pytestmark = [pytest.mark.extra_rbac]
 
 
-def _build_view_edit_permission_check(allowed_or_denied, get_view_or_edit):
+def _build_view_edit_allow(get_view_or_edit):
     """Helper to build multiple objects check functions"""
 
     def check(*objects):
         for adcm_object in objects:
-            allowed_or_denied(adcm_object, get_view_or_edit(adcm_object))
+            is_allowed(adcm_object, get_view_or_edit(adcm_object))
 
     return check
 
 
-is_allowed_to_view = _build_view_edit_permission_check(is_allowed, BR.view_config_of)
-is_allowed_to_edit = _build_view_edit_permission_check(is_allowed, BR.edit_config_of)
-is_denied_to_view = _build_view_edit_permission_check(is_denied, BR.view_config_of)
-is_denied_to_edit = _build_view_edit_permission_check(is_denied, BR.edit_config_of)
+def _build_view_edit_deny(get_view_or_edit):
+    """Helper to build multiple objects deny check functions"""
+
+    def check(*objects, client=None):
+        for adcm_object in objects:
+            is_denied(adcm_object, get_view_or_edit(adcm_object), client=client)
+
+    return check
+
+
+is_allowed_to_view = _build_view_edit_allow(BR.view_config_of)
+is_allowed_to_edit = _build_view_edit_allow(BR.edit_config_of)
+is_denied_to_view = _build_view_edit_deny(BR.view_config_of)
+is_denied_to_edit = _build_view_edit_deny(BR.edit_config_of)
 
 
 @use_role(CLUSTER_VIEW_CONFIG_ROLES)
 def test_view_application_configurations(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
     """Test that View application configuration role is ok"""
-    cluster, service, component, provider, host = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, *_ = prepare_objects
-    user_second_objects = as_user_objects(user_sdk, *second_objects)
-    second_service_on_first_cluster = user_sdk.service(id=cluster_via_admin.service_add(name="new_service").id)
+    cluster, service, component, provider, host = prepare_objects
+    second_service_on_first_cluster = cluster.service_add(name="new_service")
     second_component_on_first_cluster = second_service_on_first_cluster.component(name="test_component")
 
-    objects_affected_by_policy = (
+    objects_affected_by_policy = as_user_objects(
+        user_sdk,
         cluster,
         service,
         component,
@@ -70,349 +79,369 @@ def test_view_application_configurations(user_policy: Policy, user_sdk: ADCMClie
     )
 
     is_allowed_to_view(*objects_affected_by_policy)
-    is_denied_to_edit(*objects_affected_by_policy)
-    is_denied_to_view(provider, host, *user_second_objects)
+    is_denied_to_edit(*objects_affected_by_policy, client=user_sdk)
+    is_denied_to_view(provider, host, *second_objects, client=user_sdk)
     delete_policy(user_policy)
-    is_denied_to_view(*objects_affected_by_policy)
+    is_denied_to_view(*objects_affected_by_policy, client=user_sdk)
 
 
 @use_role(PROVIDER_VIEW_CONFIG_ROLES)
 def test_view_infrastructure_configurations(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
     """Test that View infrastructure configuration role is ok"""
-    cluster, service, component, provider, host = as_user_objects(user_sdk, *prepare_objects)
-    *_, provider_via_admin, _ = prepare_objects
-    user_second_objects = as_user_objects(user_sdk, *second_objects)
-    second_host_on_first_provider = user_sdk.host(id=provider_via_admin.host_create(fqdn="new_host").id)
+    cluster, service, component, provider, host = prepare_objects
+    second_host_on_first_provider = provider.host_create(fqdn="new_host")
 
     # second host on first provider will be allowed to view because of provider's permission
-    is_allowed_to_view(provider, host, second_host_on_first_provider)
-    is_denied_to_edit(provider, host, second_host_on_first_provider)
-    is_denied_to_view(cluster, service, component, *user_second_objects)
+    allowed_to_view_objects = as_user_objects(user_sdk, provider, host, second_host_on_first_provider)
+    is_allowed_to_view(*allowed_to_view_objects)
+    is_denied_to_edit(*allowed_to_view_objects, client=user_sdk)
+    is_denied_to_view(cluster, service, component, *second_objects, client=user_sdk)
     delete_policy(user_policy)
-    is_denied_to_view(provider, host)
+    is_denied_to_view(*allowed_to_view_objects, client=user_sdk)
 
 
 @use_role(CLUSTER_EDIT_CONFIG_ROLES)
 def test_edit_application_configurations(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
     """Test that Edit application configuration role is ok"""
-    cluster, service, component, provider, host = as_user_objects(user_sdk, *prepare_objects)
-    user_second_objects = as_user_objects(user_sdk, *second_objects)
+    cluster, service, component, provider, host = prepare_objects
 
-    is_allowed_to_view(cluster, service, component)
-    is_allowed_to_edit(cluster, service, component)
-    is_denied_to_edit(*user_second_objects, user_sdk.adcm(), provider, host)
+    allowed_user_objects = as_user_objects(user_sdk, cluster, service, component)
+    is_allowed_to_view(*allowed_user_objects)
+    is_allowed_to_edit(*allowed_user_objects)
+    is_denied_to_edit(*second_objects, user_sdk.adcm(), provider, host, client=user_sdk)
     delete_policy(user_policy)
-    is_denied_to_edit(cluster, service, component)
-    is_denied_to_view(cluster, service, component)
+    is_denied_to_edit(*allowed_user_objects, client=user_sdk)
+    is_denied_to_view(*allowed_user_objects, client=user_sdk)
 
 
 @use_role(PROVIDER_EDIT_CONFIG_ROLES)
 def test_edit_infrastructure_configurations(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
     """Test that Edit infrastructure configuration role is ok"""
-    cluster, service, component, provider, host = as_user_objects(user_sdk, *prepare_objects)
-    user_second_objects = as_user_objects(user_sdk, *second_objects)
+    cluster, service, component, provider, host = prepare_objects
 
-    is_allowed_to_view(provider, host)
-    is_allowed_to_edit(provider, host)
-    is_denied_to_edit(*user_second_objects, user_sdk.adcm(), cluster, service, component)
+    allowed_user_objects = as_user_objects(user_sdk, provider, host)
+    is_allowed_to_view(*allowed_user_objects)
+    is_allowed_to_edit(*allowed_user_objects)
+    is_denied_to_edit(*second_objects, user_sdk.adcm(), cluster, service, component, client=user_sdk)
     delete_policy(user_policy)
-    is_denied_to_edit(provider, host)
-    is_denied_to_view(provider, host)
+    is_denied_to_edit(*allowed_user_objects, client=user_sdk)
+    is_denied_to_view(*allowed_user_objects, client=user_sdk)
 
 
 @use_role(BR.ViewImports)
-def test_view_imports(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_view_imports(user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that View imports role is ok"""
-    cluster, service, *_ = as_user_objects(user_sdk, *prepare_objects)
-    second_cluster, second_service, *_ = as_user_objects(user_sdk, *second_objects)
-    for base_object in [cluster, service]:
+    admin_cluster_second, admin_service_second, *_ = second_objects
+    cluster, service = as_user_objects(user_sdk, *prepare_objects[:2])
+    for base_object in (cluster, service):
         is_allowed(base_object, BR.ViewImports)
-        is_denied(base_object, BR.ManageImports, second_service)
-    for base_object in [second_cluster, second_service]:
-        is_denied(base_object, BR.ViewImports)
+        is_denied_to_user(base_object, BR.ManageImports)
+    for base_object in (admin_cluster_second, admin_service_second):
+        is_denied_to_user(base_object, BR.ViewImports)
     delete_policy(user_policy)
-    for base_object in [cluster, service]:
-        is_denied(base_object, BR.ViewImports)
+    for base_object in (cluster, service):
+        is_denied_to_user(base_object, BR.ViewImports)
 
 
 @use_role(BR.ManageImports)
-def test_manage_imports(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_manage_imports(user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Manage imports role is ok"""
-    cluster, service, *_ = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, service_via_admin, *_ = prepare_objects
-    second_cluster, second_service, *_ = as_user_objects(user_sdk, *second_objects)
+    admin_cluster, admin_service, *_ = prepare_objects
+    cluster, service = as_user_objects(user_sdk, admin_cluster, admin_service)
+    admin_cluster_second, admin_service_second, *_ = second_objects
 
     for base_object in [cluster, service]:
         is_allowed(base_object, BR.ViewImports)
-        is_allowed(base_object, BR.ManageImports, second_service)
-    for base_object in [second_cluster, second_service]:
-        is_denied(base_object, BR.ViewImports)
+        is_allowed(base_object, BR.ManageImports, admin_service_second)
+    for base_object in [admin_cluster_second, admin_service_second]:
+        is_denied_to_user(base_object, BR.ViewImports)
     delete_policy(user_policy)
-    _ = (bind.delete() for bind in cluster_via_admin.bind_list())
-    _ = (bind.delete() for bind in service_via_admin.bind_list())
-    for base_object in [cluster, service]:
-        is_denied(base_object, BR.ViewImports)
-        is_denied(base_object, BR.ManageImports, second_service)
+    # TODO remove binds (check out commit history)
+    for base_object in [admin_cluster, admin_service]:
+        is_denied_to_user(base_object, BR.ViewImports)
+        is_denied_to_user(base_object, BR.ManageImports, admin_service_second)
 
 
 @use_role(BR.ViewHostComponents)
-def test_view_hostcomponents(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_view_hostcomponents(
+    user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects
+):
     """Test that View host-components role is ok"""
-    cluster, _, component, _, host = as_user_objects(user_sdk, *prepare_objects)
     cluster_via_admin, *_, host_via_admin = prepare_objects
-    second_cluster, *_ = as_user_objects(user_sdk, *second_objects)
+    cluster, *_ = as_user_objects(user_sdk, cluster_via_admin)
+    second_cluster_via_admin, *_ = second_objects
     cluster_via_admin.host_add(host_via_admin)
 
     is_allowed(cluster, BR.ViewHostComponents)
-    is_denied(second_cluster, BR.ViewHostComponents)
-    is_denied(cluster, BR.EditHostComponents, (host, component))
+    is_denied_to_user(second_cluster_via_admin, BR.ViewHostComponents)
+    is_denied_to_user(cluster, BR.EditHostComponents)
     delete_policy(user_policy)
-    is_denied(cluster, BR.ViewHostComponents)
+    is_denied_to_user(cluster, BR.ViewHostComponents)
 
 
 @use_role(BR.EditHostComponents)
-def test_edit_hostcomponents(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_edit_hostcomponents(
+    user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects
+):
     """Test that Edit host-components role is ok"""
-    cluster, _, component, _, host = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, *_, host_via_admin = prepare_objects
-    second_cluster, _, second_component, _, second_host = as_user_objects(user_sdk, *second_objects)
+
+    cluster_via_admin, _, component_via_admin, _, host_via_admin = prepare_objects
     second_cluster_via_admin, *_, second_host_via_admin = second_objects
+    cluster, *_ = as_user_objects(user_sdk, cluster_via_admin)
 
     cluster_via_admin.host_add(host_via_admin)
     second_cluster_via_admin.host_add(second_host_via_admin)
 
     is_allowed(cluster, BR.ViewHostComponents)
-    is_allowed(cluster, BR.EditHostComponents, (host, component))
-    is_denied(second_cluster, BR.ViewHostComponents)
-    is_denied(second_cluster, BR.EditHostComponents, (second_host, second_component))
+    is_allowed(cluster, BR.EditHostComponents, (host_via_admin, component_via_admin))
+    is_denied_to_user(second_cluster_via_admin, BR.ViewHostComponents)
+    is_denied_to_user(second_cluster_via_admin, BR.EditHostComponents)
     delete_policy(user_policy)
-    is_denied(cluster, BR.ViewHostComponents)
-    is_denied(cluster, BR.EditHostComponents)
+    is_denied_to_user(cluster, BR.ViewHostComponents)
+    is_denied_to_user(cluster, BR.EditHostComponents)
 
 
 @use_role(BR.AddService)
-def test_add_service(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_add_service(user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Add service role is ok"""
-    cluster, *_ = as_user_objects(user_sdk, *prepare_objects)
     cluster_via_admin, *_ = prepare_objects
-    second_cluster, *_ = as_user_objects(user_sdk, *second_objects)
+    cluster, *_ = as_user_objects(user_sdk, cluster_via_admin)
+    second_cluster_via_admin, *_ = second_objects
 
     is_allowed(cluster, BR.AddService)
     added_service = cluster.service(name="new_service")
-    is_denied(cluster, BR.RemoveService, added_service)
-    is_denied(second_cluster, BR.AddService)
+    is_denied_to_user(cluster, BR.RemoveService, added_service)
+    is_denied_to_user(second_cluster_via_admin, BR.AddService)
     cluster_via_admin.service(name="new_service").delete()
     delete_policy(user_policy)
-    is_denied(cluster, BR.AddService)
+    is_denied_to_user(cluster, BR.AddService)
 
 
 @use_role(BR.RemoveService)
-def test_remove_service(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_remove_service(user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Remove service role is ok"""
-    cluster, service, *_ = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, *_ = prepare_objects
-    second_cluster, second_service, *_ = as_user_objects(user_sdk, *second_objects)
+    cluster_via_admin, service_via_admin, *_ = prepare_objects
+    cluster, *_ = as_user_objects(user_sdk, cluster_via_admin)
     second_cluster_via_admin, *_ = second_objects
 
-    is_denied(cluster, BR.AddService)
-    is_allowed(cluster, BR.RemoveService, service)
-    is_denied(second_cluster, BR.RemoveService, second_service)
+    is_denied_to_user(cluster_via_admin, BR.AddService)
+    is_allowed(cluster, BR.RemoveService, service_via_admin)
+    is_denied_to_user(cluster_via_admin, BR.RemoveService)
 
-    added_second_service = second_cluster_via_admin.service_add(name="new_service")
-    is_denied(cluster, BR.RemoveService, added_second_service)
+    second_cluster_via_admin.service_add(name="new_service")
+    is_denied_to_user(second_cluster_via_admin, BR.RemoveService)
 
     delete_policy(user_policy)
-    added_service = cluster_via_admin.service_add(name="test_service")
-    is_denied(cluster, BR.RemoveService, added_service)
+    cluster_via_admin.service_add(name="test_service")
+    is_denied_to_user(cluster_via_admin, BR.RemoveService)
 
 
 @use_role(BR.RemoveHosts)
-def test_remove_hosts(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects, sdk_client_fs, user):
+def test_remove_hosts(
+    user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects, sdk_client_fs, user
+):
     """Test that Remove hosts role is ok"""
-    *_, host = as_user_objects(user_sdk, *prepare_objects)
-    *_, second_host = as_user_objects(user_sdk, *second_objects)
+    *_, admin_host = prepare_objects
+    *_, admin_host_second = second_objects
+    *_, host = as_user_objects(user_sdk, admin_host)
 
     is_allowed(host, BR.RemoveHosts)
-    is_denied(second_host, BR.RemoveHosts)
+    is_denied_to_user(admin_host_second, BR.RemoveHosts)
     with allure.step("Assert that policy is valid after object removing"):
         user_policy.reread()
 
-    new_policy = create_policy(sdk_client_fs, BR.RemoveHosts, objects=[second_host], users=[user], groups=[])
+    new_policy = create_policy(sdk_client_fs, BR.RemoveHosts, objects=[admin_host_second], users=[user], groups=[])
     delete_policy(new_policy)
-    is_denied(second_host, BR.RemoveHosts)
+    is_denied_to_user(admin_host_second, BR.RemoveHosts)
 
 
 @use_role(BR.MapHosts)
-def test_map_hosts(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_map_hosts(user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Map hosts role is ok"""
-    cluster, *_, host = as_user_objects(user_sdk, *prepare_objects)
-    *_, provider_via_admin, _ = prepare_objects
-    second_cluster, *_, second_host = as_user_objects(user_sdk, *second_objects)
+    admin_cluster, *_, admin_host = prepare_objects
+    cluster, *_ = as_user_objects(user_sdk, admin_cluster)
+    admin_cluster_second, *_, admin_provider, _ = second_objects
 
-    new_host = provider_via_admin.host_create(fqdn="new_host")
-    is_allowed(cluster, BR.MapHosts, host)
-    is_denied(cluster, BR.UnmapHosts, host)
-    is_denied(second_cluster, BR.MapHosts, second_host)
+    new_host = admin_provider.host_create(fqdn="new_host")
+    is_allowed(cluster, BR.MapHosts, admin_host)
+    is_denied_to_user(admin_host, BR.UnmapHosts)
+    is_denied_to_user(admin_cluster_second, BR.MapHosts)
 
     delete_policy(user_policy)
 
-    is_denied(cluster, BR.MapHosts, new_host)
+    is_denied_to_user(new_host, BR.MapHosts)
 
 
 @use_role(BR.UnmapHosts)
-def test_unmap_hosts(user_policy: Policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_unmap_hosts(user_policy: Policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Unmap hosts role is ok"""
-    cluster, *_, host = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, *_, provider_via_admin, _ = prepare_objects
-    second_cluster, *_, second_host = as_user_objects(user_sdk, *second_objects)
-    second_cluster_via_admin, *_ = second_objects
+    cluster_via_admin, *_, provider_via_admin, host_via_admin = prepare_objects
+    cluster, *_ = as_user_objects(user_sdk, cluster_via_admin)
+    second_cluster_via_admin, *_, second_host_via_admin = second_objects
 
-    is_denied(cluster, BR.MapHosts, host)
-    is_denied(host, BR.RemoveHosts)
-    cluster_via_admin.host_add(host)
+    is_denied_to_user(cluster, BR.MapHosts)
+    is_denied_to_user(host_via_admin, BR.RemoveHosts)
+    cluster_via_admin.host_add(host_via_admin)
+    host, *_ = as_user_objects(user_sdk, *prepare_objects)
     is_allowed(cluster, BR.UnmapHosts, host)
 
-    second_cluster_via_admin.host_add(second_host)
-    is_denied(second_cluster, BR.UnmapHosts, second_host)
+    second_cluster_via_admin.host_add(second_host_via_admin)
+    is_denied_to_user(second_host_via_admin, BR.UnmapHosts)
 
     delete_policy(user_policy)
 
     new_host = provider_via_admin.host_create(fqdn="new_host")
     cluster_via_admin.host_add(new_host)
-    is_denied(cluster, BR.UnmapHosts, new_host)
+    is_denied_to_user(new_host, BR.UnmapHosts)
 
 
 @use_role(BR.UpgradeClusterBundle)
 @pytest.mark.usefixtures("second_objects")
-def test_upgrade_application_bundle(user_policy, user_sdk: ADCMClient, prepare_objects, sdk_client_fs, user):
+def test_upgrade_application_bundle(
+    user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, sdk_client_fs, user
+):
     """Test that Upgrade application bundle role is ok"""
-    cluster, *_, provider, _ = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, *_ = prepare_objects
-    second_cluster = user_sdk.cluster(id=cluster_via_admin.bundle().cluster_create(name="Second cluster").id)
+    cluster_via_admin, *_, provider_via_admin, _ = prepare_objects
+    cluster, *_ = as_user_objects(user_sdk, cluster_via_admin)
+    second_cluster_via_admin = cluster_via_admin.bundle().cluster_create(name="Second cluster")
 
     is_allowed(cluster, BR.UpgradeClusterBundle)
-    is_denied(provider, BR.UpgradeClusterBundle)
-    is_denied(second_cluster, BR.UpgradeClusterBundle)
+    is_denied_to_user(provider_via_admin, BR.UpgradeProviderBundle)
+    is_denied_to_user(second_cluster_via_admin, BR.UpgradeClusterBundle)
 
     new_policy = create_policy(
-        sdk_client_fs, BR.UpgradeClusterBundle, objects=[second_cluster], users=[user], groups=[]
+        sdk_client_fs, BR.UpgradeClusterBundle, objects=[second_cluster_via_admin], users=[user], groups=[]
     )
     delete_policy(new_policy)
-    is_denied(second_cluster, BR.UpgradeClusterBundle)
+    is_denied_to_user(second_cluster_via_admin, BR.UpgradeClusterBundle)
 
 
 @use_role(BR.UpgradeProviderBundle)
 @pytest.mark.usefixtures("second_objects")
-def test_upgrade_infrastructure_bundle(user_policy, user_sdk: ADCMClient, prepare_objects, sdk_client_fs, user):
+def test_upgrade_infrastructure_bundle(
+    user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, sdk_client_fs, user
+):
     """Test that Upgrade infrastructure bundle role is ok"""
-    cluster, *_, provider, _ = as_user_objects(user_sdk, *prepare_objects)
-    *_, provider_via_admin, _ = prepare_objects
-    second_provider = user_sdk.provider(id=provider_via_admin.bundle().provider_create(name="Second provider").id)
+    cluster_via_admin, *_, provider_via_admin, _ = prepare_objects
+    provider, *_ = as_user_objects(user_sdk, provider_via_admin)
+    second_provider_via_admin = provider_via_admin.bundle().provider_create(name="Second provider")
 
     is_allowed(provider, BR.UpgradeProviderBundle)
-    is_denied(cluster, BR.UpgradeProviderBundle)
-    is_denied(second_provider, BR.UpgradeProviderBundle)
+    is_denied_to_user(cluster_via_admin, BR.UpgradeClusterBundle)
+    is_denied_to_user(second_provider_via_admin, BR.UpgradeProviderBundle)
 
     new_policy = create_policy(
-        sdk_client_fs, BR.UpgradeProviderBundle, objects=[second_provider], users=[user], groups=[]
+        sdk_client_fs, BR.UpgradeProviderBundle, objects=[second_provider_via_admin], users=[user], groups=[]
     )
     delete_policy(new_policy)
-    is_denied(second_provider, BR.UpgradeProviderBundle)
+    is_denied_to_user(second_provider_via_admin, BR.UpgradeProviderBundle)
 
 
 @use_role(BR.CreateHostProvider)
-def test_create_provider(user_policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_create_provider(user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Create provider role is ok"""
-    cluster, *_, provider, _ = as_user_objects(user_sdk, *prepare_objects)
-    *_, second_provider, _ = as_user_objects(user_sdk, *second_objects)
+    cluster, *_, provider, _ = prepare_objects
+    *_, second_provider, _ = second_objects
+    provider_bundle_first, provider_bundle_second = as_user_objects(
+        user_sdk, provider.bundle(), second_provider.bundle()
+    )
 
-    is_allowed(provider.bundle(), BR.CreateHostProvider)
-    is_allowed(second_provider.bundle(), BR.CreateHostProvider)
-    is_denied(provider, BR.CreateHost)
-    is_denied(user_sdk.provider_list()[-1], BR.CreateHost)
-    is_denied(cluster.bundle(), BR.CreateCluster)
+    is_allowed(provider_bundle_first, BR.CreateHostProvider)
+    is_allowed(provider_bundle_second, BR.CreateHostProvider)
+    is_denied_to_user(provider, BR.CreateHost)
+    is_denied_to_user(provider, BR.CreateHost)
+    is_denied_to_user(cluster.bundle(), BR.CreateCluster)
 
     delete_policy(user_policy)
-    is_denied(provider.bundle(), BR.CreateHostProvider)
+    is_denied_to_user(provider.bundle(), BR.CreateHostProvider)
 
 
 @use_role(BR.CreateHost)
-def test_create_host(user_policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_create_host(user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Create host role is ok"""
-    cluster, *_, provider, host = as_user_objects(user_sdk, *prepare_objects)
-    *_, second_provider, second_host = as_user_objects(user_sdk, *second_objects)
+    admin_cluster, *_, admin_provider, admin_host = prepare_objects
+    provider, *_ = as_user_objects(user_sdk, admin_provider)
+    *_, admin_second_provider, admin_second_host = second_objects
 
     is_allowed(provider, BR.CreateHost)
-    is_denied(host, BR.RemoveHosts)
-    is_denied(cluster, BR.MapHosts, host)
-    is_denied(second_provider, BR.CreateHost)
-    is_denied(second_host, BR.RemoveHosts)
+    is_denied_to_user(admin_host, BR.RemoveHosts)
+    is_denied_to_user(admin_cluster, BR.MapHosts, admin_host)
+    is_denied_to_user(admin_second_provider, BR.CreateHost)
+    is_denied_to_user(admin_second_host, BR.RemoveHosts)
 
     delete_policy(user_policy)
-    is_denied(provider, BR.CreateHost)
+    is_denied_to_user(admin_provider, BR.CreateHost)
 
 
 @use_role(BR.RemoveHostProvider)
-def test_remove_provider(user_policy, user_sdk: ADCMClient, prepare_objects, second_objects, sdk_client_fs, user):
+def test_remove_provider(
+    user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects, sdk_client_fs, user
+):
     """Test that Remove provider role is ok"""
-    *_, provider, host = as_user_objects(user_sdk, *prepare_objects)
-    *_, host_via_admin = prepare_objects
-    *_, second_provider, _ = as_user_objects(user_sdk, *second_objects)
-    *_, second_host_via_admin = second_objects
+    *_, provider_via_admin, host_via_admin = prepare_objects
+    provider, *_ = as_user_objects(user_sdk, provider_via_admin)
 
-    is_denied(host, BR.RemoveHosts)
+    *_, second_provider_via_admin, second_host_via_admin = second_objects
+
+    is_denied_to_user(host_via_admin, BR.RemoveHosts)
     host_via_admin.delete()
     second_host_via_admin.delete()
     is_allowed(provider, BR.RemoveHostProvider)
-    is_denied(second_provider, BR.RemoveHostProvider)
+    is_denied_to_user(second_provider_via_admin, BR.RemoveHostProvider)
 
-    new_policy = create_policy(sdk_client_fs, BR.RemoveHostProvider, objects=[second_provider], users=[user], groups=[])
+    new_policy = create_policy(
+        sdk_client_fs, BR.RemoveHostProvider, objects=[second_provider_via_admin], users=[user], groups=[]
+    )
     delete_policy(new_policy)
-    is_denied(second_provider, BR.RemoveHostProvider)
+    is_denied_to_user(second_provider_via_admin, BR.RemoveHostProvider)
 
 
 @use_role(BR.CreateCluster)
-def test_create_cluster(user_policy, user_sdk: ADCMClient, prepare_objects, second_objects):
+def test_create_cluster(user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects):
     """Test that Create cluster role is ok"""
-    cluster, *_, provider, _ = as_user_objects(user_sdk, *prepare_objects)
+    cluster, *_, provider, _ = prepare_objects
+    cluster_bundle, *_ = as_user_objects(user_sdk, cluster.bundle())
 
-    is_allowed(cluster.bundle(), BR.CreateCluster)
-    is_denied(provider.bundle(), BR.CreateHostProvider)
-    is_denied(cluster, BR.RemoveCluster)
+    is_allowed(cluster_bundle, BR.CreateCluster)
+    is_denied_to_user(provider.bundle(), BR.CreateHostProvider)
+    is_denied_to_user(cluster, BR.RemoveCluster)
 
     delete_policy(user_policy)
-    is_denied(cluster.bundle(), BR.CreateCluster)
+    is_denied_to_user(cluster_bundle, BR.CreateCluster)
 
 
 @use_role(BR.RemoveCluster)
-def test_remove_cluster(user_policy, user_sdk: ADCMClient, prepare_objects, second_objects, sdk_client_fs, user):
+def test_remove_cluster(
+    user_policy, user_sdk: ADCMClient, is_denied_to_user, prepare_objects, second_objects, sdk_client_fs, user
+):
     """Test that Remove cluster role is ok"""
-    cluster, *_ = as_user_objects(user_sdk, *prepare_objects)
-    second_cluster, *_ = as_user_objects(user_sdk, *second_objects)
+    admin_cluster, *_ = prepare_objects
+    admin_cluster_second, *_ = second_objects
+    cluster, *_ = as_user_objects(user_sdk, admin_cluster)
 
-    is_denied(cluster.bundle(), BR.CreateCluster)
+    is_denied_to_user(admin_cluster.bundle(), BR.CreateCluster)
     is_allowed(cluster, BR.RemoveCluster)
-    is_denied(second_cluster, BR.RemoveCluster)
+    is_denied_to_user(admin_cluster_second, BR.RemoveCluster)
 
-    new_policy = create_policy(sdk_client_fs, BR.RemoveCluster, objects=[second_cluster], users=[user], groups=[])
+    new_policy = create_policy(sdk_client_fs, BR.RemoveCluster, objects=[admin_cluster_second], users=[user], groups=[])
     delete_policy(new_policy)
-    is_denied(second_cluster, BR.RemoveCluster)
+    is_denied_to_user(admin_cluster_second, BR.RemoveCluster)
 
 
 @use_role(BR.UploadBundle)
-def test_upload_bundle(user_policy, user_sdk: ADCMClient, sdk_client_fs):
+def test_upload_bundle(clients, user_policy, is_denied_to_user):
     """Test that Upload bundle role is ok"""
 
-    is_allowed(user_sdk, BR.UploadBundle)
-    is_denied(user_sdk.bundle(), BR.RemoveBundle)
+    is_allowed(clients.user, BR.UploadBundle)
+    is_denied_to_user(clients.admin.bundle(), BR.RemoveBundle)
 
     delete_policy(user_policy)
-    sdk_client_fs.bundle_list()[-1].delete()
-    is_denied(user_sdk, BR.UploadBundle)
+    clients.admin.bundle_list()[-1].delete()
+    is_denied(clients.user, BR.UploadBundle)
 
 
 @use_role(BR.RemoveBundle)
-def test_remove_bundle(user_policy, user_sdk: ADCMClient, sdk_client_fs):
+def test_remove_bundle(user_policy, user_sdk: ADCMClient, sdk_client_fs, is_denied_to_user):
     """Test that Remove bundle role is ok"""
 
     is_denied(user_sdk, BR.UploadBundle)
@@ -421,82 +450,75 @@ def test_remove_bundle(user_policy, user_sdk: ADCMClient, sdk_client_fs):
 
     delete_policy(user_policy)
     BR.UploadBundle.value.method_call(sdk_client_fs)
-    is_denied(user_sdk.bundle_list()[-1], BR.RemoveBundle)
+    is_denied_to_user(user_sdk.bundle_list()[-1], BR.RemoveBundle)
 
 
 def test_service_administrator(user, user_sdk: ADCMClient, sdk_client_fs, prepare_objects, second_objects):
     """Test that service administrator role grants access to single service and its components"""
-    cluster, service, component, *provider_objects = as_user_objects(user_sdk, *prepare_objects)
-    cluster_via_admin, *_ = prepare_objects
-    second_service_on_first_cluster = user_sdk.service(id=cluster_via_admin.service_add(name="new_service").id)
-    second_cluster, second_service, second_component, *second_provider_objects = as_user_objects(
-        user_sdk, *second_objects
-    )
+    cluster, service, component, *provider_objects = prepare_objects
+    second_service_on_first_cluster = cluster.service_add(name="new_service")
 
     role = sdk_client_fs.role(name=RbacRoles.ServiceAdministrator.value)
     sdk_client_fs.policy_create(
         name=f"Policy with role {role.name}", role=role, objects=[service], user=[user], group=[]
     )
 
-    is_allowed_to_view(service, component)
-    is_allowed_to_edit(service, component)
-    is_denied_to_view(
-        cluster,
-        second_cluster,
-        second_service,
-        second_component,
-        second_service_on_first_cluster,
-        *provider_objects,
-        *second_provider_objects,
-    )
+    allowed_user_objects = as_user_objects(user_sdk, service, component)
+    is_allowed_to_view(*allowed_user_objects)
+    is_allowed_to_edit(*allowed_user_objects)
+    is_denied_to_view(cluster, second_service_on_first_cluster, *second_objects, *provider_objects, client=user_sdk)
 
 
 def test_cluster_administrator(user, user_sdk: ADCMClient, sdk_client_fs, prepare_objects, second_objects):
     """Test that cluster administrator role grants access to single cluster and related services and components"""
-    cluster, service, component, *provider_objects = as_user_objects(user_sdk, *prepare_objects)
-    second_cluster, second_service, second_component, *second_provider_objects = as_user_objects(
-        user_sdk, *second_objects
-    )
+    cluster, service, component, *provider_objects = prepare_objects
 
     role = sdk_client_fs.role(name=RbacRoles.ClusterAdministrator.value)
     sdk_client_fs.policy_create(
         name=f"Policy with role {role.name}", role=role, objects=[cluster], user=[user], group=[]
     )
 
-    is_allowed_to_view(cluster, service, component)
-    is_allowed_to_edit(cluster, service, component)
-    is_denied_to_view(second_cluster, second_service, second_component, *provider_objects, *second_provider_objects)
+    allowed_user_objects = as_user_objects(user_sdk, cluster, service, component)
+    is_allowed_to_view(*allowed_user_objects)
+    is_allowed_to_edit(*allowed_user_objects)
+    is_denied_to_view(*second_objects, *provider_objects, client=user_sdk)
 
 
 def test_provider_administrator(user, user_sdk: ADCMClient, sdk_client_fs, prepare_objects, second_objects):
     """Test that provider administrator role grants access to single provider and its hosts"""
-    cluster, service, component, hostprovider, host = as_user_objects(user_sdk, *prepare_objects)
-    second_cluster, second_service, second_component, *second_provider_objects = as_user_objects(
-        user_sdk, *second_objects
-    )
+    cluster, service, component, hostprovider, host = prepare_objects
+    second_cluster, second_service, second_component, *second_provider_objects = second_objects
 
     role = sdk_client_fs.role(name=RbacRoles.ProviderAdministrator.value)
     sdk_client_fs.policy_create(
         name=f"Policy with role {role.name}", role=role, objects=[hostprovider], user=[user], group=[]
     )
 
-    is_allowed_to_view(hostprovider, host)
-    is_allowed_to_edit(hostprovider, host)
+    user_hostprovider, user_host = as_user_objects(user_sdk, hostprovider, host)
+    is_allowed_to_view(user_hostprovider, user_host)
+    is_allowed_to_edit(user_hostprovider, user_host)
     is_denied_to_view(
-        cluster, service, component, second_cluster, second_service, second_component, *second_provider_objects
+        cluster,
+        service,
+        component,
+        second_cluster,
+        second_service,
+        second_component,
+        *second_provider_objects,
+        client=user_sdk,
     )
 
 
-def test_any_object_roles(clients, user, prepare_objects):
+def test_any_object_roles(clients, user, is_denied_to_user, prepare_objects):
     """Test that ViewAnyObject... default roles works as expected with ADCM User"""
-    cluster, *_ = user_objects = as_user_objects(clients.user, *prepare_objects)
+    admin_cluster, *_ = prepare_objects
 
     @allure.step("Check user has no access to any of objects")
     def check_has_no_rights():
-        is_denied(cluster, BR.ViewAnyObjectImport)
-        is_denied(cluster, BR.ViewAnyObjectHostComponents)
-        is_denied_to_view(*user_objects)
-        is_denied_to_edit(*user_objects)
+        is_denied_to_user(admin_cluster, BR.ViewAnyObjectImport, client=clients.user)
+        is_denied_to_user(admin_cluster, BR.ViewAnyObjectHostComponents, client=clients.user)
+        is_denied_to_view(*prepare_objects, client=clients.user)
+        is_denied_to_edit(*prepare_objects, client=clients.user)
 
     check_has_no_rights()
 
@@ -507,10 +529,12 @@ def test_any_object_roles(clients, user, prepare_objects):
         user=[user],
     )
 
+    cluster, *_ = as_user_objects(clients.user, admin_cluster)
+
     is_allowed(cluster, BR.ViewAnyObjectImport)
     is_allowed(cluster, BR.ViewAnyObjectHostComponents)
-    is_allowed_to_view(*user_objects)
-    is_denied_to_edit(*user_objects)
+    is_allowed_to_view(*as_user_objects(clients.user, *prepare_objects))
+    is_denied_to_edit(*prepare_objects, client=clients.user)
 
     delete_policy(policy)
 

--- a/tests/functional/tools.py
+++ b/tests/functional/tools.py
@@ -20,7 +20,21 @@ import pytest
 from _pytest.outcomes import Failed
 from coreapi.exceptions import ErrorMessage
 from adcm_client.base import ObjectNotFound, PagingEnds
-from adcm_client.objects import Host, Task, Job, Cluster, Service, Component, Provider, GroupConfig, ADCMClient
+from adcm_client.objects import (
+    Host,
+    Task,
+    Job,
+    Cluster,
+    Service,
+    Component,
+    Provider,
+    GroupConfig,
+    ADCMClient,
+    Policy,
+    Role,
+    Group,
+    User,
+)
 from adcm_pytest_plugin.utils import catch_failed
 
 
@@ -28,10 +42,12 @@ BEFORE_UPGRADE_DEFAULT_STATE = None
 
 
 ADCMObjects = (Cluster, Service, Component, Provider, Host)
+RBACObjects = (User, Group, Role, Policy)
 
 ClusterRelatedObject = Union[Cluster, Service, Component]
 ProviderRelatedObject = Union[Provider, Host]
 AnyADCMObject = Union[ClusterRelatedObject, ProviderRelatedObject, ADCMClient]
+AnyRBACObject = Union[User, Group, Role, Policy]
 
 
 def get_config(adcm_object: AnyADCMObject):

--- a/tests/library/consts.py
+++ b/tests/library/consts.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 """Common consts for tests"""
+from enum import Enum
 
 
 class States:  # pylint: disable=too-few-public-methods
@@ -25,3 +26,13 @@ class MessageStates:  # pylint: disable=too-few-public-methods
 
     fail_msg = 'fail_msg'
     success_msg = 'success_msg'
+
+
+class HTTPMethod(Enum):  # pylint: disable=too-few-public-methods
+    """HTTP methods"""
+
+    GET = 'get'
+    POST = 'post'
+    PUT = 'put'
+    PATCH = 'patch'
+    DELETE = 'delete'

--- a/tests/ui_tests/app/page/admin/page.py
+++ b/tests/ui_tests/app/page/admin/page.py
@@ -417,7 +417,7 @@ class AdminRolesPage(GeneralAdminPage):
             AdminRoleInfo.build(
                 name='Cluster Administrator',
                 description='',
-                permissions=CLUSTER_ADMIN_ROLES,
+                permissions=CLUSTER_ADMIN_ROLES - SERVICE_ADMIN_ROLES | {'Service Administrator'},
             ),
             AdminRoleInfo.build(
                 name='Provider Administrator',

--- a/tests/ui_tests/app/page/admin/page.py
+++ b/tests/ui_tests/app/page/admin/page.py
@@ -16,12 +16,20 @@ from dataclasses import dataclass
 from typing import (
     List,
     Optional,
+    Union,
+    Iterable,
 )
 
 import allure
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.remote.webelement import WebElement
 
+from tests.functional.rbac.test_built_in_roles_composition import (
+    ADCM_USER_ROLES,
+    SERVICE_ADMIN_ROLES,
+    CLUSTER_ADMIN_ROLES,
+    PROVIDER_ADMIN_ROLES,
+)
 from tests.ui_tests.app.helpers.locator import Locator
 from tests.ui_tests.app.page.admin.locators import (
     AdminUsersLocators,
@@ -53,6 +61,14 @@ class AdminRoleInfo:
     name: str
     description: str
     permissions: str
+
+    @classmethod
+    def build(cls, name, description, permissions: Union[str, Iterable[str]]):
+        if isinstance(permissions, str):
+            permissions_ = set(perm.strip() for perm in permissions.split(','))
+        else:
+            permissions_ = set(permissions)
+        return cls(name, description, permissions_)
 
 
 @dataclass
@@ -374,7 +390,7 @@ class AdminRolesPage(GeneralAdminPage):
         roles_items = []
         role_rows = self.table.get_all_rows()
         for row in role_rows:
-            row_item = AdminRoleInfo(
+            row_item = AdminRoleInfo.build(
                 name=self.find_child(row, AdminRolesLocators.RoleRow.name).text,
                 description=self.find_child(row, AdminRolesLocators.RoleRow.description).text,
                 permissions=self.find_child(row, AdminRolesLocators.RoleRow.permissions).text,
@@ -386,36 +402,33 @@ class AdminRolesPage(GeneralAdminPage):
     def check_default_roles(self):
         """Check default roles are listed on admin page"""
 
+        # move it to page class
         default_roles = [
-            AdminRoleInfo(
+            AdminRoleInfo.build(
                 name='ADCM User',
                 description='',
-                permissions='View any object configuration, View any object import, View any object host-components',
+                permissions=ADCM_USER_ROLES,
             ),
-            AdminRoleInfo(
+            AdminRoleInfo.build(
                 name='Service Administrator',
                 description='',
-                permissions='View host configurations, Edit service configurations, Edit component configurations, '
-                'Manage imports, View host-components',
+                permissions=SERVICE_ADMIN_ROLES,
             ),
-            AdminRoleInfo(
+            AdminRoleInfo.build(
                 name='Cluster Administrator',
                 description='',
-                permissions='Create host, Upload bundle, Edit cluster configurations, Edit host configurations, '
-                'Add service, Remove service, Remove hosts, Map hosts, Unmap hosts, Edit host-components, '
-                'Upgrade cluster bundle, Remove bundle, Service Administrator',
+                permissions=CLUSTER_ADMIN_ROLES,
             ),
-            AdminRoleInfo(
+            AdminRoleInfo.build(
                 name='Provider Administrator',
                 description='',
-                permissions='Create host, Upload bundle, Edit provider configurations, Edit host configurations, '
-                'Remove hosts, Upgrade provider bundle, Remove bundle',
+                permissions=PROVIDER_ADMIN_ROLES,
             ),
         ]
 
         roles = self.get_all_roles_info()
         for role in default_roles:
-            assert role in roles, f"Default role {role.name} is wrong or missing"
+            assert role in roles, f"Default role {role.name} is wrong or missing. Expected to find: {role} in {roles}"
 
     @allure.step('Check custom roles')
     def check_custom_role(self, role: AdminRoleInfo):


### PR DESCRIPTION
Main changes:
- `is_denied` logic is changed to check permissions on interactions with objects directly via API, not via the client (ADCM client is checked the way it was)
- "user" objects are now received not at the start of the test and only those objects that are requested are the ones the user has permission for

Pay attention to:
- `is_denied` requires either ADCM client as `adcm_object` or ADCM object + client (by kwarg) to perform the correct check
- `is_allowed` operates only on "non-superuser" user objects it the alternative isn't set directly