### PR TITLE
Add sshpass to allow password SSH connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apk update && \
         runit \
         nginx \
         openssh-client \
-        logrotate
+        logrotate \
+        sshpass
 COPY requirements*.txt /adcm/
 RUN pip install --upgrade pip &&  \
     pip install --no-cache-dir -r /adcm/requirements-venv-default.txt && \


### PR DESCRIPTION
I can see "to use the 'ssh' connection type with passwords, you must install the sshpass program" when try to use SSH Common host provider with password defined. Let's install sshpass as required.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>