### PR TITLE
Fix secret key location and ensure existence

### DIFF
--- a/os/etc/sv/init/run
+++ b/os/etc/sv/init/run
@@ -44,7 +44,8 @@ key=/root/.ssh/id_rsa
 if [ ! -f "${adcmvar}"/cluster.db ]; then
     echo "Assume first run, generate Django secret key"
     "${adcmroot}"/python/manage.py generate_secret_key
-    mv "${adcmroot}/python/secretkey.txt" "${adcmsecretfile}"
+    # generate_secret_key creates file in the current directory with secretkey.txt name
+    mv secretkey.txt "${adcmsecretfile}"
 fi
 
 if [ ! \( -f "${adcmuserconf}/ssl/cert.pem" -a -f "${adcmuserconf}/ssl/key.pem" \) ]; then

--- a/os/etc/sv/init/run
+++ b/os/etc/sv/init/run
@@ -41,7 +41,7 @@ echo "Root keys generation"
 key=/root/.ssh/id_rsa
 [ ! -f ${key} ] && ssh-keygen -f ${key} -t rsa -N ""
 
-if [ ! -f "${adcmvar}"/cluster.db ]; then
+if [ ! -f "${adcmsecretfile}" ]; then
     echo "Assume first run, generate Django secret key"
     "${adcmroot}"/python/manage.py generate_secret_key
     # generate_secret_key creates file in the current directory with secretkey.txt name


### PR DESCRIPTION
Two fixes spitted into separate commits:

1. generate_secret_key [stores](https://github.com/MickaelBergem/django-generate-secret-key/blob/91d974a1870a40bdaac93f7037a6a0af85eeaaa6/django_generate_secret_key/management/commands/generate_secret_key.py#L40) the key into the current location, so we should use it from there.
2. It is nice to have the secret file in place in order to not invalidate sessions (for example download logs of jobs) after restart of container (as we will [generate](https://github.com/arenadata/adcm/blob/d41b7685535b060fbdc7251c6a6b0e127df1b862/python/adcm/settings.py#L69) new key on fly if no file stored), so let's check for the key existence to generate it.