### PR TITLE
Secure Setting for Django SESSION_COOKIE_SECURE flag

### DIFF
--- a/python/audit/management/commands/clearaudit.py
+++ b/python/audit/management/commands/clearaudit.py
@@ -179,7 +179,7 @@ class Command(BaseCommand):
         header = None
         if Path(path).is_file():
             with open(path, encoding=settings.ENCODING_UTF_8) as csv_file:
-                header = csv_file.readline().strip().split(",")
+                header = csv_file.readline(5_000_000).strip().split(",")
         return header
 
     def __log(self, msg, method="info"):


### PR DESCRIPTION
This codemod will set Django's `SESSION_COOKIE_SECURE` flag to `True` if it's `False` or missing on the `settings.py` file within Django's default directory structure.

```diff
+ SESSION_COOKIE_SECURE = True
```

Setting this flag on ensures that the session cookies are only sent under an HTTPS connection. Leaving this flag off may enable an attacker to use a sniffer to capture the unencrypted session cookie and hijack the user's session.

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/controls/SecureCookieAttribute](https://owasp.org/www-community/controls/SecureCookieAttribute)
  * [https://docs.djangoproject.com/en/4.2/ref/settings/#session-cookie-secure](https://docs.djangoproject.com/en/4.2/ref/settings/#session-cookie-secure)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:python/django-session-cookie-secure-off](https://docs.pixee.ai/codemods/python/pixee_python_django-session-cookie-secure-off) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fadcm%7Cb653601ebfeb3f03d7b9d6d331bdaef3ece80c73)