### PR TITLE
Fix concurrent access to ADCM token cache

### DIFF
--- a/go/adcm/status/auth.go
+++ b/go/adcm/status/auth.go
@@ -21,14 +21,14 @@ import (
 func checkADCMUserToken(hub Hub, token string) bool {
 	checkADCMAuth := func(token string) bool {
 		if hub.AdcmApi.checkAuth(token) {
-			hub.Secrets.adcmTokens[token] = time.Now().Add(hub.Secrets.tokenTimeOut)
+			hub.Secrets.SetADCMToken(token)
 			return true
-		} else {
-			return false
 		}
+
+		return false
 	}
 
-	val, ok := hub.Secrets.adcmTokens[token]
+	val, ok := hub.Secrets.GetADCMToken(token)
 	if !ok {
 		return checkADCMAuth(token)
 	}

--- a/go/adcm/status/auth_test.go
+++ b/go/adcm/status/auth_test.go
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"adcm/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestCheckADCMUserTokenConcurrent(t *testing.T) {
+	InitLog("", "CRITICAL")
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+	}
+
+	secrets := NewSecretConfig(config.AccessTokens{})
+	hub := Hub{
+		Secrets: secrets,
+		AdcmApi: &AdcmApi{
+			Url:        "http://adcm.test",
+			httpClient: httpClient,
+			Secrets:    secrets,
+		},
+	}
+
+	const workers = 100
+	start := make(chan struct{})
+	results := make(chan bool, workers)
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-start
+			results <- checkADCMUserToken(hub, fmt.Sprintf("token-%d", id))
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for authenticated := range results {
+		if !authenticated {
+			t.Fatal("expected every concurrent token check to succeed")
+		}
+	}
+
+	for i := 0; i < workers; i++ {
+		if _, ok := secrets.GetADCMToken(fmt.Sprintf("token-%d", i)); !ok {
+			t.Fatalf("expected token-%d to be cached", i)
+		}
+	}
+}

--- a/go/adcm/status/secretconfig.go
+++ b/go/adcm/status/secretconfig.go
@@ -13,14 +13,17 @@
 package status
 
 import (
-	"adcm/config"
+	"sync"
 	"time"
+
+	"adcm/config"
 )
 
 type SecretConfig struct {
 	AccessTokens config.AccessTokens
 	adcmTokens   map[string]time.Time
 	tokenTimeOut time.Duration
+	mu           sync.RWMutex
 }
 
 func NewSecretConfig(accessTokens config.AccessTokens) *SecretConfig {
@@ -29,4 +32,19 @@ func NewSecretConfig(accessTokens config.AccessTokens) *SecretConfig {
 		adcmTokens:   map[string]time.Time{},
 		tokenTimeOut: 60 * time.Minute,
 	}
+}
+
+func (sc *SecretConfig) SetADCMToken(token string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.adcmTokens[token] = time.Now().Add(sc.tokenTimeOut)
+}
+
+func (sc *SecretConfig) GetADCMToken(token string) (time.Time, bool) {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+
+	val, ok := sc.adcmTokens[token]
+	return val, ok
 }


### PR DESCRIPTION
## Проблема

Сервис статуса ADCM хранит токены аутентифицированных пользователей в обычном Go-отображении (map). HTTP-запросы обрабатываются параллельно, поэтому несколько запросов могут одновременно читать и записывать в это отображение.

Это может вызвать гонку данных (data race) или привести к завершению работы сервиса статуса с ошибкой:

`fatal error: concurrent map read and map write`

Кэш токенов теперь защищён с помощью `sync.RWMutex`. Добавлен регрессионный тест на корректность работы в конкурентной среде.

## Влияние на другие продукты

Другие продукты не затронуты. Проблема и исправление изолированы в сервисе статуса ADCM на Go и не меняют его API или внешнее поведение.
