### PR TITLE
Fix concurrent access to host duplicates registry

### DIFF
--- a/go/adcm/status/init.go
+++ b/go/adcm/status/init.go
@@ -24,7 +24,7 @@ import (
 )
 
 const httpPort = ":8020"
-const componentTimeout = 300 // seconds
+const componentTimeout = 300 * time.Second
 
 type Hub struct {
 	HostStatusStorage    *Storage

--- a/go/adcm/status/storage.go
+++ b/go/adcm/status/storage.go
@@ -13,6 +13,8 @@
 package status
 
 import (
+	"maps"
+	"slices"
 	"sync"
 	"time"
 )
@@ -47,7 +49,7 @@ const (
 	cmdGet   = "get"
 	cmdGet1  = "get1"
 
-	statusTimeOut = 60 // seconds
+	statusTimeOut = 60 * time.Second
 )
 
 type dbStorage interface {
@@ -63,7 +65,7 @@ type Storage struct {
 	in      chan storageRequest
 	out     chan storageResponse
 	dbMap   dbStorage
-	timeout int
+	timeout time.Duration
 	label   string
 }
 
@@ -87,24 +89,15 @@ func newMMObjects() *MMObjects {
 }
 
 func (mm *MMObjects) IsHostInMM(hostID int) bool {
-	return intSliceContains(mm.data.Hosts, hostID)
+	return slices.Contains(mm.data.Hosts, hostID)
 }
 
 func (mm *MMObjects) IsServiceInMM(serviceID int) bool {
-	return intSliceContains(mm.data.Services, serviceID)
+	return slices.Contains(mm.data.Services, serviceID)
 }
 
 func (mm *MMObjects) IsComponentInMM(componentID int) bool {
-	return intSliceContains(mm.data.Components, componentID)
-}
-
-func intSliceContains(a []int, x int) bool {
-	for _, n := range a {
-		if x == n {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(mm.data.Components, componentID)
 }
 
 // Host Duplicates
@@ -115,15 +108,14 @@ type HostDuplicates struct {
 	// To get duplicate ids iterate over second level keys retrieved by original host ID.
 	//
 	// First key is Original Host ID,
-	// Second key is Duplicate Host ID,
-	// Value by duplicate id is meaningless integer.
-	duplicates map[int]map[int]int
-	mutex      sync.Mutex
+	// Second key is Duplicate Host ID.
+	duplicates map[int]map[int]struct{}
+	mutex      sync.RWMutex
 }
 
 func newHostDuplicates() *HostDuplicates {
 	return &HostDuplicates{
-		duplicates: make(map[int]map[int]int),
+		duplicates: make(map[int]map[int]struct{}),
 	}
 }
 
@@ -134,28 +126,20 @@ func (hd *HostDuplicates) Register(original int, duplicates []int) {
 	registeredDuplicates, exists := hd.duplicates[original]
 
 	if !exists {
-		registeredDuplicates = make(map[int]int, len(duplicates))
+		registeredDuplicates = make(map[int]struct{}, len(duplicates))
 		hd.duplicates[original] = registeredDuplicates
 	}
 
 	for _, id := range duplicates {
-		registeredDuplicates[id] = 0
+		registeredDuplicates[id] = struct{}{}
 	}
 }
 
 func (hd *HostDuplicates) GetForID(original int) []int {
-	duplicates, exists := hd.duplicates[original]
-	if !exists {
-		return []int{}
-	}
+	hd.mutex.RLock()
+	defer hd.mutex.RUnlock()
 
-	out := make([]int, 0, len(hd.duplicates))
-
-	for id := range duplicates {
-		out = append(out, id)
-	}
-
-	return out
+	return slices.Collect(maps.Keys(hd.duplicates[original]))
 }
 
 // Server
@@ -170,7 +154,7 @@ func newStorage(db dbStorage, label string) *Storage {
 	}
 }
 
-func (s *Storage) setTimeOut(timeout int) {
+func (s *Storage) setTimeOut(timeout time.Duration) {
 	s.timeout = timeout
 }
 
@@ -291,7 +275,7 @@ func (s *Storage) startTimer(db dbStorage, c storageRequest) {
 	c.counter = counter
 	c.command = cmdClear
 	go func(c storageRequest) {
-		time.Sleep(time.Duration(s.timeout) * time.Second)
+		time.Sleep(s.timeout)
 		s.in <- c
 	}(c)
 }

--- a/go/adcm/status/storage_test.go
+++ b/go/adcm/status/storage_test.go
@@ -12,7 +12,10 @@
 
 package status
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestHostDuplicates(t *testing.T) {
 	// Data
@@ -65,5 +68,51 @@ func TestHostDuplicates(t *testing.T) {
 	actual = hd.GetForID(notExist)
 	if len(actual) != 0 {
 		t.Errorf("expected empty for not existing id, got: %d", actual)
+	}
+}
+
+// TestHostDuplicatesConcurrent guards against unsynchronized access to the duplicates map.
+// Register and GetForID are called from concurrent HTTP handlers
+// (POST /host-duplicates/ and POST /host/:hostid/ respectively),
+// so GetForID must take the same mutex as Register.
+// Without that the test crashes with "concurrent map read and map write"
+// or, with -race, reports a DATA RACE on every run.
+func TestHostDuplicatesConcurrent(t *testing.T) {
+	hd := newHostDuplicates()
+
+	const (
+		workers    = 100
+		iterations = 100
+		// Every worker also hammers this key, so readers and writers
+		// constantly collide on the same inner map, not only on the outer one.
+		sharedID = 100000
+	)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				hd.Register(id, []int{id + 1, id + 2})
+				hd.GetForID(id)
+				hd.Register(sharedID, []int{id})
+				hd.GetForID(sharedID)
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i := 0; i < workers; i++ {
+		if got := hd.GetForID(i); len(got) != 2 {
+			t.Errorf("expected 2 duplicates for id %d, got %d: %d", i, len(got), got)
+		}
+	}
+	if got := hd.GetForID(sharedID); len(got) != workers {
+		t.Errorf("expected %d duplicates for shared id, got %d", workers, len(got))
 	}
 }

--- a/go/adcm/status/storage_test.go
+++ b/go/adcm/status/storage_test.go
@@ -91,17 +91,15 @@ func TestHostDuplicatesConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for j := 0; j < iterations; j++ {
-				hd.Register(id, []int{id + 1, id + 2})
-				hd.GetForID(id)
-				hd.Register(sharedID, []int{id})
+				hd.Register(i, []int{i + 1, i + 2})
+				hd.GetForID(i)
+				hd.Register(sharedID, []int{i})
 				hd.GetForID(sharedID)
 			}
-		}(i)
+		})
 	}
 
 	close(start)


### PR DESCRIPTION
GetForID read the duplicates map without taking the mutex while Register wrote to it under lock, so concurrent POST /host/:hostid/ and POST /host-duplicates/ requests could crash the server with "concurrent map read and map write". Covered by a concurrent test that reliably fails without the fix (with and without -race).

Also, while here:
- store duplicates as map[int]struct{} instead of a meaningless int
- use time.Duration for storage timeouts instead of raw seconds
- replace hand-written intSliceContains with slices.Contains